### PR TITLE
Added proper get/setValue methods to TextArea

### DIFF
--- a/src/backbone-forms.js
+++ b/src/backbone-forms.js
@@ -638,7 +638,15 @@
 
     editors.TextArea = editors.Text.extend({
 
-       tagName: 'textarea'
+        tagName: 'textarea',
+
+        setValue : function(value) {
+			$(this.el).html(value);
+		},
+
+		getValue : function() {
+			return $(this.el).html();
+		}
 
     });
     


### PR DESCRIPTION
I expirienced some problems with TextArea editors.
The value weren't set at each render process.
I added a get/setValue method on TextAreas and the problem seems to be solved.
