### PR TITLE
Don’t rely on the global $ variable.

### DIFF
--- a/src/backbone-forms.js
+++ b/src/backbone-forms.js
@@ -1,4 +1,4 @@
-;(function() {
+;(function($) {
     
     //Support paths for nested attributes e.g. 'user.name'
     function getNested(obj, path) {
@@ -1090,4 +1090,4 @@
     Form.validators = validators;
     module.exports = Backbone.Form = Form;
 
-})();
+}(jQuery));


### PR DESCRIPTION
It might not be present if, or be something different than jQuery when jQuery.noConflict(); has been run.
