### PR TITLE
Fix Hidden field bug (check for this.$help)

### DIFF
--- a/src/backbone-forms.js
+++ b/src/backbone-forms.js
@@ -684,11 +684,14 @@
        
       this.$el.removeClass(errClass);
       
-      this.$help.empty();
+      // some fields (e.g., Hidden), may not have a help el
+      if (this.$help) {
+        this.$help.empty();
       
-      //Reset help text if available
-      var helpMsg = this.schema.help;
-      if (helpMsg) this.$help.html(helpMsg);
+        //Reset help text if available
+        var helpMsg = this.schema.help;
+        if (helpMsg) this.$help.html(helpMsg);
+      }
     },
 
     /**


### PR DESCRIPTION
Check for `this.$help` to avoid errors (Hidden fields don't have error div element)

Bug could be seen when have a List whose NestedModel contained a Hidden field. When editing an item of the list there was an error due to having a field with type Hidden.
