### PR TITLE
Fix popup form so Enter doesn't submit form in browser when form doesn't validate

### DIFF
--- a/src/jquery-ui-editors.js
+++ b/src/jquery-ui-editors.js
@@ -362,6 +362,10 @@
         schema: schema,
         value: data
       }).render();
+
+      // prevent brower default form submission due to Enter key
+      var frm = editor.$('form');
+      frm.submit(function(e) { e.preventDefault(); });
       
       var container = $(this.editorTemplate());
       $('.bbf-list-editor', container).html(editor.el);


### PR DESCRIPTION
Bug only shows itself when the form doesn't validate correctly (e.g., a required field wasn't filled out and Enter was pressed)
