### PR TITLE
Allow field templates to be specified in schema

### DIFF
--- a/src/backbone-forms.js
+++ b/src/backbone-forms.js
@@ -604,6 +604,7 @@
       var schema = this.schema;
       if (!schema.type) schema.type = 'Text';
       if (!schema.title) schema.title = helpers.keyToTitle(this.key);
+      if (!schema.template) schema.template = 'field';
     },
 
     render: function() {
@@ -629,7 +630,7 @@
       var editor = this.editor = helpers.createEditor(schema.type, options);
       
       //Create the element
-      var $field = $(templates.field({
+      var $field = $(templates[schema.template]({
         key: this.key,
         title: schema.title,
         id: editor.id,

--- a/test/field.js
+++ b/test/field.js
@@ -95,6 +95,17 @@ test("'schema.fieldAttrs' option - Adds custom attributes", function() {
   equal($el.attr('custom'), 'hello');
 })
 
+test("'schema.template' option - Specifies template", function() {
+  Form.templates.custom = Form.helpers.createTemplate('<div class="custom-field"></div>');
+  
+  var field = new Field({
+    key: 'title',
+    schema: { template: 'custom' }
+  }).render();
+  
+  ok(field.$el.hasClass('custom-field'));
+})
+
 test("'model' option - Populates the field with the given 'key' option from the model", function() {
     var field = new Field({
         model: new Post,


### PR DESCRIPTION
This pull request allows field templates to be specified in a form schema.

```
Backbone.Form.helpers.setTemplates({
    form: '...',
    fieldset: '...',
    field: '...',
    custom: '...'
}, ...);
```

```
schema: {
    foo: { type: 'Text', template: 'custom' }
}
```

Defaults to the `field` template.
