### PR TITLE
make defining the schema of sub-models optional 

### DIFF
--- a/src/backbone-forms.js
+++ b/src/backbone-forms.js
@@ -339,7 +339,7 @@
       
         if (_.isFunction(model.schema)) return model.schema();
       
-        return model.schema;
+        return (model.schema) ? model.schema : {};
       })();
       
       //Handle other options


### PR DESCRIPTION
... by not erroring if the schema attribute is not defined on the model - instead return an empty object as the schema
