### PR TITLE
Stop removing siblings to placeholders

### DIFF
--- a/src/backbone-forms.js
+++ b/src/backbone-forms.js
@@ -396,10 +396,10 @@
         }
 
         //Concatenating HTML as strings won't work so we need to insert field elements into a placeholder
-        var $fieldset = $(templates.fieldset(_.extend({}, fs, {
+        var $fieldset = $(templates.fieldset({
           legend: (fs.legend) ? '<legend>' + fs.legend + '</legend>' : '',
           fields: '<div class="bbf-placeholder"></div>'
-        })));
+        }));
 
         var $fieldsContainer = $('.bbf-placeholder', $fieldset);
 


### PR DESCRIPTION
Previously the parent of placeholders were emptied meaning siblings were removed.

For example this template:

```
<div>
  <p>foo</p>
  {{editor}}
</div>
```

Would be rendered as:

```
<div>
  <input ...>
</div>
```
