### PR TITLE
Fixes

### DIFF
--- a/src/backbone-forms.js
+++ b/src/backbone-forms.js
@@ -373,7 +373,6 @@
      */
     render: function() {
       var self = this,
-          fieldsToRender = this.fieldsToRender,
           fieldsets = this.fieldsets,
           templates = Form.templates;
       
@@ -386,7 +385,7 @@
       var $fieldsetContainer = $('.bbf-placeholder', $form);
 
       if(!fieldsets) {
-        fieldsets = [{}]
+        fieldsets = [{fields: this.fieldsToRender}]
       }
 
       //TODO: Update handling of fieldsets


### PR DESCRIPTION
Previously the placeholder parents were being emptied, now the
placeholder is filled and later removed leaving its children.

The following template

```
<div>
  <p>Foo</p>
  {{editor}}
</div>
```

Would be rendered as

```
<div>
  <input ...>
</div>
```

Because the parent of the placeholder was being emptied.
