### PR TITLE
Fix select

### DIFF
--- a/distribution/backbone-forms.amd.js
+++ b/distribution/backbone-forms.amd.js
@@ -1208,8 +1208,7 @@ define('backbone-forms', ['jquery', 'Backbone'], function() {
       //Generate HTML
       _.each(array, function(option) {
         if (_.isObject(option)) {
-          var val = option.val ? option.val : '';
-          html.push('<option value="'+val+'">'+option.label+'</option>');
+          html.push('<option value="'+option.val+'">'+option.label+'</option>');
         }
         else {
           html.push('<option>'+option+'</option>');


### PR DESCRIPTION
Option didn't have a value if option.val evaluated to false. This
fails in my use case of enumerating a collection from 0:

```
  [
    {val: 0, label: "first item"},
    {val: 1, label: "second item"},
    ...
  ]
```
