### PR TITLE
Pressing enter in a list now adds a new item to the bottom of the list

### DIFF
--- a/src/editors/list.js
+++ b/src/editors/list.js
@@ -194,6 +194,12 @@
       'click [data-action="remove"]': function(event) {
         event.preventDefault();
         this.list.removeItem(this);
+      },
+      'keydown input[type=text]': function(event) {
+        if(event.keyCode != 13) return;
+        event.preventDefault();
+        this.list.addItem();
+        this.list.$list.find("> li:last input").focus();
       }
     },
 


### PR DESCRIPTION
This addresses https://github.com/powmedia/backbone-forms/issues/72 in part.
This doesn't solve the fact that pressing enter on a form element outside the list triggers an item to be removed
