### PR TITLE
Added a ReadOnlyDate editor

### DIFF
--- a/src/editors.js
+++ b/src/editors.js
@@ -695,6 +695,7 @@ Form.editors = (function() {
       if(!this.value || this.value == ""){
         this.setValue(displayValue);
         this.$el.attr('readonly', true);
+        return this;
       }
       
       if(this.value.format){


### PR DESCRIPTION
A read only date editor that uses a read-only text input box to display a formatted date. Built in date format parser accepts:
dd - the date (always two chars)
mm - the month number (always two chars)
mmmm - the month name (English only though could very easily be internationalized)
yyyy - the full year

It also checks for the existence of a date formatting plugin (like http://blog.stevenlevithan.com/archives/date-time-format). The plugin needs to add a .format method to the date object.

If no date format is specified, it defaults to dd/mm/yyyy.

Use in the schema like this: 
createDate: {type: "ReadOnlyDate" dateFormat: "dd/mm/yyyy"}

*\* Note my regex skills are dreadful so there's probably a faster/better way to parse the format strings
