### PR TITLE
Fix rendering of radio button fields with spaces in values

### DIFF
--- a/src/editors.js
+++ b/src/editors.js
@@ -463,7 +463,7 @@ Form.editors = (function() {
     },
 
     setValue: function(value) {
-      this.$el.find('input[type=radio][value='+value+']').attr('checked', true);
+      this.$el.find('input[type=radio][value="'+value+'"]').attr('checked', true);
     },
 
     /**


### PR DESCRIPTION
I am writing a "wizard" type of app using backbone-forms that has the behavior of re-rendering backbone-forms views that have already been `commit()`ed.  With radio button fields that have _spaces_ in the values, selecting one these values, `commit()`ing it and re-rendering it always sets the `checked` HTML attribute to the last value in the list rather than the one that was selected.  Here's an example:

``` javascript
var RadioWithSpaces = Backbone.Model.extend({
    schema: {
        test: { type: 'Radio', options: ['foo bar', 'baz', 'quux'] }
    }
});
```

If you select `foo bar` and commit the form, then re-render it, the HTML that gets rendered looks like this (with `quux` checked):

``` html
<ul id="test" class="bbf-radio" name="test">
  <li>
    <input type="radio" name="test" value="foo bar" id="test-0">
    <label for="test-0">foo bar</label>
  </li>
  <li>
    <input type="radio" name="test" value="baz" id="test-1">
    <label for="test-1">baz</label>
  </li>
  <li>
    <input type="radio" name="test" value="quux" id="test-2" checked="checked">
    <label for="test-2">quux</label>
  </li>
</ul>
```

rather than the expected

``` html
<ul id="test" class="bbf-radio" name="test">
  <li>
    <input type="radio" name="test" value="foo bar" id="test-0" checked="checked">
    <label for="test-0">foo bar</label>
  </li>
  <li>
    <input type="radio" name="test" value="baz" id="test-1">
    <label for="test-1">baz</label>
  </li>
  <li>
    <input type="radio" name="test" value="quux" id="test-2">
    <label for="test-2">quux</label>
  </li>
</ul>
```

Interestingly it looks like [checkboxes](https://github.com/powmedia/backbone-forms/blob/master/src/editors.js#L525) already do this correctly.

Apologies for not writing an actual test case for this; kind of busy at work atm.
