### PR TITLE
Setting value with setValue only from form.schema

### DIFF
--- a/src/form.js
+++ b/src/form.js
@@ -285,8 +285,11 @@ var Form = (function() {
      * @param {Object} data     New values to set
      */
     setValue: function(data) {
-      for (var key in data) {
-        this.fields[key].setValue(data[key]);
+      var key;
+      for (key in this.schema) {
+        if (data[key] !== undefined) {
+          this.fields[key].setValue(data[key]);
+        }
       }
     },
 

--- a/test/form.js
+++ b/test/form.js
@@ -282,6 +282,20 @@ test("setValue() - updates form field values", function() {
     equal(form.fields.author.getValue(), 'Sterling Archer');
 });
 
+test("setValue() - updates only field from schema", function() {
+    var form = new Form({
+        model: new Post
+    }).render();
+    
+    form.setValue({
+        title: 'Danger Zone 2',
+        fakeField: 'FakeTest'
+    });
+    
+    // Check undefined schema field
+    equal(typeof form.fields.fakeField, 'undefined');
+});
+
 test("remove() - removes all child views and itself", function() {
     var counter = 0;
     


### PR DESCRIPTION
For convenient use of
form.setValue(model.toJSON()) when
shema: {
  id: 'Number',
  name: 'Text'
}

and model.toJSON():
{
  id: 1,
  name: 'Name',
  otherKey: 'Other'
}

Before it - use case form.setValue(model.toJSON()) throws error. And now it will populates only values from schema. I think it can be useful.
