### PR TITLE
Fixes model errors not being return by validate()

### DIFF
--- a/src/form.js
+++ b/src/form.js
@@ -223,6 +223,7 @@ var Form = (function() {
               //Set error on field if there isn't one already
               if (self.fields[key] && !errors[key]) {
                 self.fields[key].setError(val);
+                errors[key] = val;
               }
               
               else {


### PR DESCRIPTION
Models that have a validate function and return errors in the format

```
  {field: 'error message'}
```

are being skipped. The error message is added to the field, but form.validate() doesn't return the error, causing the form to appear valid.
