### PR TITLE
Validator now errors if required field has value of false (i.e. an unchecked checkbox)

### DIFF
--- a/src/validators.js
+++ b/src/validators.js
@@ -1,4 +1,4 @@
-  
+
 //==================================================================================================
 //VALIDATORS
 //==================================================================================================
@@ -14,87 +14,87 @@ Form.validators = (function() {
     url: 'Invalid URL',
     match: 'Must match field "{{field}}"'
   }
-  
+
   validators.required = function(options) {
     options = _.extend({
       type: 'required',
       message: this.errMessages.required
     }, options);
-     
+
     return function required(value) {
       options.value = value;
-      
+
       var err = {
         type: options.type,
         message: Form.helpers.createTemplate(options.message, options)
       };
-      
-      if (value === null || value === undefined || value === '') return err;
+
+      if (value === null || value === undefined || value === '' || value === false) return err;
     };
   };
-  
+
   validators.regexp = function(options) {
     if (!options.regexp) throw new Error('Missing required "regexp" option for "regexp" validator');
-  
+
     options = _.extend({
       type: 'regexp',
       message: this.errMessages.regexp
     }, options);
-    
+
     return function regexp(value) {
       options.value = value;
-      
+
       var err = {
         type: options.type,
         message: Form.helpers.createTemplate(options.message, options)
       };
-      
+
       //Don't check empty values (add a 'required' validator for this)
       if (value === null || value === undefined || value === '') return;
 
       if (!options.regexp.test(value)) return err;
     };
   };
-  
+
   validators.email = function(options) {
     options = _.extend({
       type: 'email',
       message: this.errMessages.email,
       regexp: /^[\w\-]{1,}([\w\-\+.]{1,1}[\w\-]{1,}){0,}[@][\w\-]{1,}([.]([\w\-]{1,})){1,3}$/
     }, options);
-    
+
     return validators.regexp(options);
   };
-  
+
   validators.url = function(options) {
     options = _.extend({
       type: 'url',
       message: this.errMessages.url,
       regexp: /^(http|https):\/\/(([A-Z0-9][A-Z0-9_-]*)(\.[A-Z0-9][A-Z0-9_-]*)+)(:(\d+))?\/?/i
     }, options);
-    
+
     return validators.regexp(options);
   };
-  
+
   validators.match = function(options) {
     if (!options.field) throw new Error('Missing required "field" options for "match" validator');
-    
+
     options = _.extend({
       type: 'match',
       message: this.errMessages.match
     }, options);
-    
+
     return function match(value, attrs) {
       options.value = value;
-      
+
       var err = {
         type: options.type,
         message: Form.helpers.createTemplate(options.message, options)
       };
-      
+
       //Don't check empty values (add a 'required' validator for this)
       if (value === null || value === undefined || value === '') return;
-      
+
       if (value != attrs[options.field]) return err;
     }
   };

--- a/test/validators.js
+++ b/test/validators.js
@@ -1,44 +1,47 @@
 ;(function() {
 
   module('general')
-  
+
   test('can change default error messages with mustache tags', function() {
     var originalMessage = Form.validators.errMessages.email;
-    
+
     Form.validators.errMessages.email = '{{value}} is an invalid email address. {{customTag}}.'
-    
+
     var email = Form.validators.email({ customTag: 'Cool beans' })
     equal(email('foo').message, 'foo is an invalid email address. Cool beans.')
-    
+
     //Restore original message
     Form.validators.errMessages.email = originalMessage;
   })
-  
+
 })();
 
 
 ;(function() {
 
   module('required')
-  
+
   var required = Form.validators.required()
 
   test('error if field is null or undefined', function() {
     ok(required(null))
     ok(required())
   })
-  
+
   test('error if field is empty string', function() {
-    ok(required(''))
-    equal(required('test', undefined))
+      ok(required(''))
+      equal(required('test', undefined))
   })
-  
+
+  test('error if field is false', function() {
+      ok(required(false))
+  })
+
   test('ok if field is number 0', function() {
-    equal(required(0), undefined)
+    equal(required(1), undefined)
   })
-  
-  test('ok if field is boolean', function() {
-    equal(required(false), undefined)
+
+  test('ok if field is true', function() {
     equal(required(true), undefined)
   })
 
@@ -48,7 +51,7 @@
 ;(function() {
 
   module('regexp')
-  
+
   var fn = Form.validators.regexp({
     regexp: /foo/
   });
@@ -58,12 +61,12 @@
     equal(fn(null), undefined)
     equal(fn(undefined), undefined)
   })
-  
+
   test('fails invalid strings', function() {
     equal(fn('gsurkbfsr').type, 'regexp')
     equal(fn('guerbayf').message, 'Invalid')
   })
-  
+
   test('passes valid strings', function() {
     equal(fn('foo'), undefined)
     equal(fn('_foo_'), undefined)
@@ -74,15 +77,15 @@
 
 ;(function() {
   module('email')
-  
+
   var fn = Form.validators.email()
-  
+
   test('passes empty values', function() {
     equal(fn(''), undefined)
     equal(fn(null), undefined)
     equal(fn(undefined), undefined)
   })
-  
+
   test('fails invalid emails', function() {
     ok(fn('invalid'))
     ok(fn('email@example'))
@@ -91,7 +94,7 @@
     ok(fn('foo@exa#mple.com'))
     ok(fn(234))
   })
-  
+
   test('accepts valid emails', function() {
     equal(fn('test@example.com'), undefined)
     equal(fn('john.smith@example.com'), undefined)
@@ -99,21 +102,21 @@
     equal(fn('john-smith@example.com'), undefined)
     equal(fn('john+smith@example.com'), undefined)
   })
-  
+
 })();
 
 
 ;(function() {
   module('url')
-  
+
   var fn = Form.validators.url()
-  
+
   test('passes empty values', function() {
     equal(fn(''), undefined)
     equal(fn(null), undefined)
     equal(fn(undefined), undefined)
   })
-  
+
   test('fails invalid url', function() {
     ok(fn('invalid'))
     ok(fn('example.com'))
@@ -122,7 +125,7 @@
     ok(fn('http://example'))
     ok(fn(234))
   })
-  
+
   test('accepts valid urls', function() {
     equal(fn('http://example.com'), undefined)
     equal(fn('http://example.co.uk'), undefined)
@@ -132,40 +135,40 @@
     equal(fn('http://www.example.com/path/1/2'), undefined)
     equal(fn('http://www.example.com/path/1/2?q=str'), undefined)
   })
-  
+
 })();
 
 
 ;(function() {
   module('match')
-  
+
   var fn = Form.validators.match({
     field: 'confirm'
   });
-  
+
   test('passes empty values', function() {
     equal(fn(''), undefined)
     equal(fn(null), undefined)
     equal(fn(undefined), undefined)
   })
-  
+
   test('accepts when fields match', function() {
     var attrs = {
       password: 'foo',
       confirm: 'foo'
     };
-    
+
     equal(fn('foo', attrs), undefined)
   })
-  
+
   test('fails when fields dont match', function() {
     var attrs = {
       password: 'foo',
       confirm: 'bar'
     };
-    
+
     var err = fn('foo', attrs)
-    
+
     equal(err.type, 'match')
     equal(err.message, 'Must match field "confirm"')
   })


### PR DESCRIPTION
Required validator wasn't error-ing when I set required on a checkbox field and the checkbox wasn't checked.

value is false at this point, so I've set the validator to error when value is false.

Is there a good reason why this check for false wasn't done? I see there was a test to check it didn't fail when value was false, so I have I missed something? 
