### PR TITLE
Have Form's setValue() method skip properties that aren't defined as fields

### DIFF
--- a/src/form.js
+++ b/src/form.js
@@ -318,7 +318,9 @@ var Form = (function() {
      */
     setValue: function(data) {
       for (var key in data) {
-        this.fields[key].setValue(data[key]);
+        if (_.has(this.fields, key)) {
+          this.fields[key].setValue(data[key]);
+        }
       }
     },
     

--- a/test/form.js
+++ b/test/form.js
@@ -293,6 +293,23 @@ test("setValue() - updates form field values", function() {
     equal(form.fields.author.getValue(), 'Sterling Archer');
 });
 
+test("setValue() - ignore attributes not in form", function() {
+    var form = new Form({
+        model: new Post
+    }).render();
+    
+    form.setValue({
+      title: 'Danger Zone 3',
+      notInForm: 'Not in my form you don\'t'
+    });
+    
+    //Check changed fields
+    equal(form.fields.title.getValue(), 'Danger Zone 3');
+    
+    //Check fields that shouldn't have changed
+    equal(form.fields.author.getValue(), 'Sterling Archer');
+});
+
 test("focus() - gives focus to form and its first editor", function() {
     var form = new Form({
         model: new Post


### PR DESCRIPTION
When updating form fields with `setValue`, one may need to provide an object whose properties do not all correspond to fields in the form's schema.  Currently, `setValue` fails if such a property is present.  The fix skips properties that aren't already defined in the form schema, and includes a brief test.
