### PR TITLE
Added support for grouped selects

### DIFF
--- a/src/editors.js
+++ b/src/editors.js
@@ -574,12 +574,19 @@ Form.editors = (function() {
      */
     _arrayToHtml: function(array) {
       var html = [];
+      var self = this;
 
       //Generate HTML
       _.each(array, function(option) {
         if (_.isObject(option)) {
-          var val = option.val ? option.val : '';
-          html.push('<option value="'+val+'">'+option.label+'</option>');
+          if (option.group) {
+            html.push('<optgroup label="'+option.group+'">');
+            html.push(self._arrayToHtml(option.items));
+            html.push('</optgroup>');
+          } else {
+            var val = option.val ? option.val : '';
+            html.push('<option value="'+val+'">'+option.label+'</option>');
+          }
         }
         else {
           html.push('<option>'+option+'</option>');


### PR DESCRIPTION
Added support for grouped selects. Definition is like:

```
  type: 'Select',
  options: [
    {
      group: "Standart",
      items: ["A", "AAAA", "CNAME", "MX", "SPF", "TXT"]
    },
    {
      group: "Advanced",
      items:  ["NAPTR", "SRV", "PTR", "NS"]
    },
    {
      group: "Special",
      items: ["Redirect"]
    }
  ]
```
