### PR TITLE
Made field instance available in template as variable

### DIFF
--- a/src/field.js
+++ b/src/field.js
@@ -79,6 +79,7 @@ Form.Field = (function() {
       
       //Create the element
       var $field = $(templates[schema.template]({
+        field: this,
         key: this.key,
         title: schema.title,
         id: editor.id,


### PR DESCRIPTION
I need to add a dynamic bootstrap `add-on` to one of my text inputs. As I didn't find a way on how to access "custom attributes" of the field from inside the templates I updated the code to also pass the field instance to the templates. Once can now do something like:

Inside the backbone view:

```
@model.someField = "lala"
```

Custom template:

```
Backbone.Form.setTemplates
  'field-with-addon': '
    <div class="control-group field-{{key}}">
      <label class="control-label" for="{{id}}">{{title}}</label>
      <div class="controls">
        <div class="input-append">
          {{editor}}<span class="add-on">{{field.model.someField}}</span>
        </div>
        <div class="help-block">{{help}}</div>
      </div>
    </div>
  '
```
