### PR TITLE
Errors broken out from help

### DIFF
--- a/src/field.js
+++ b/src/field.js
@@ -84,7 +84,8 @@ Form.Field = (function() {
         id: editor.id,
         type: schema.type,
         editor: '<b class="bbf-tmp-editor"></b>',
-        help: '<b class="bbf-tmp-help"></b>'
+        help: '<b class="bbf-tmp-help"></b>',
+        error: '<b class="bbf-tmp-error"></b>'
       }));
       
       //Render editor
@@ -95,6 +96,9 @@ Form.Field = (function() {
       this.$help.empty();
       if (this.schema.help) this.$help.html(this.schema.help);
       
+      this.$error = $($('.bbf-tmp-error', $field).parent()[0]);
+      if (this.$error) this.$error.empty();
+
       //Add custom CSS class names
       if (this.schema.fieldClass) $field.addClass(this.schema.fieldClass);
       
@@ -159,7 +163,11 @@ Form.Field = (function() {
 
       this.$el.addClass(errClass);
       
-      if (this.$help) this.$help.html(msg);
+      if (this.$error) {
+        this.$error.html(msg);
+      } else if (this.$help) {
+        this.$help.html(msg);
+      }
     },
     
     /**
@@ -171,7 +179,9 @@ Form.Field = (function() {
       this.$el.removeClass(errClass);
       
       // some fields (e.g., Hidden), may not have a help el
-      if (this.$help) {
+      if (this.$error) {
+        this.$error.empty();
+      } else if (this.$help) {
         this.$help.empty();
       
         //Reset help text if available

--- a/src/templates/bootstrap.js
+++ b/src/templates/bootstrap.js
@@ -19,7 +19,8 @@
       <div class="control-group field-{{key}}">\
         <label class="control-label" for="{{id}}">{{title}}</label>\
         <div class="controls">\
-          <div class="input-xlarge">{{editor}}</div>\
+          {{editor}}\
+          <div class="help-inline">{{error}}</div>\
           <div class="help-block">{{help}}</div>\
         </div>\
       </div>\
@@ -27,7 +28,9 @@
 
     nestedField: '\
       <div class="field-{{key}}">\
-        <div title="{{title}}" class="input-xlarge">{{editor}}</div>\
+        <div title="{{title}}" class="input-xlarge">{{editor}}\
+          <div class="help-inline">{{error}}</div>\
+        </div>\
         <div class="help-block">{{help}}</div>\
       </div>\
     ',

--- a/src/templates/default.js
+++ b/src/templates/default.js
@@ -19,6 +19,7 @@
         <label for="{{id}}">{{title}}</label>\
         <div class="bbf-editor">{{editor}}</div>\
         <div class="bbf-help">{{help}}</div>\
+        <div class="bbf-error">{{error}}</div>\
       </li>\
     ',
 
@@ -27,6 +28,7 @@
         <label for="{{id}}">{{title}}</label>\
         <div class="bbf-editor">{{editor}}</div>\
         <div class="bbf-help">{{help}}</div>\
+        <div class="bbf-help">{{error}}</div>\
       </li>\
     ',
 


### PR DESCRIPTION
Hi, I posted on the Google group last night about splitting out errors from help text, so here it is. As you suggested, it will fall back on the help field if there is no error placeholder in the template, but I've added the error section to both bootstrap and default templates in the library.
