### PR TITLE
Allow the Number field type to accept decimal values

### DIFF
--- a/src/editors.js
+++ b/src/editors.js
@@ -258,6 +258,7 @@ Form.editors = (function() {
       editors.Text.prototype.initialize.call(this, options);
 
       this.$el.attr('type', 'number');
+      this.$el.attr('step', 'any');
     },
 
     /**


### PR DESCRIPTION
HTML5 input validation (at least in Chrome), prevented decimal values from being submitted.

See http://blog.isotoma.com/2012/03/html5-input-typenumber-and-decimalsfloats-in-chrome/
