### PR TITLE
Fields with options, such as Select, should handle 0 as value

### DIFF
--- a/src/editors.js
+++ b/src/editors.js
@@ -578,7 +578,7 @@ Form.editors = (function() {
       //Generate HTML
       _.each(array, function(option) {
         if (_.isObject(option)) {
-          var val = option.val ? option.val : '';
+          var val = (option.val || option.val === 0) ? option.val : '';
           html.push('<option value="'+val+'">'+option.label+'</option>');
         }
         else {
@@ -664,7 +664,7 @@ Form.editors = (function() {
       _.each(array, function(option, index) {
         var itemHtml = '<li>';
         if (_.isObject(option)) {
-          var val = option.val ? option.val : '';
+          var val = (option.val || option.val === 0) ? option.val : '';
           itemHtml += ('<input type="radio" name="'+self.id+'" value="'+val+'" id="'+self.id+'-'+index+'" />')
           itemHtml += ('<label for="'+self.id+'-'+index+'">'+option.label+'</label>')
         }
@@ -752,7 +752,7 @@ Form.editors = (function() {
       _.each(array, function(option, index) {
         var itemHtml = '<li>';
         if (_.isObject(option)) {
-          var val = option.val ? option.val : '';
+          var val = (option.val || option.val === 0) ? option.val : '';
           itemHtml += ('<input type="checkbox" name="'+self.id+'" value="'+val+'" id="'+self.id+'-'+index+'" />')
           itemHtml += ('<label for="'+self.id+'-'+index+'">'+option.label+'</label>')
         }

--- a/test/editors.js
+++ b/test/editors.js
@@ -920,8 +920,34 @@ module('Select', {
 
     });
     
-    test('TODO: Options as array of objects', function() {
+    test('Options as array of objects', function() {
+        var field = new editor({
+            schema: schema
+        }).render();
 
+        field.setOptions([
+            {
+                val: 0,
+                label: "Option 1"
+            },
+            {
+                val: 1,
+                label: "Option 2"
+            },
+            {
+                val: 2,
+                label: "Option 3"
+            }
+        ]);
+
+        var newOptions = field.$el.find('option');
+
+        equal(newOptions.length, 3);
+        equal(newOptions.first().html(), "Option 1");
+        equal(newOptions.last().html(), "Option 3");
+
+        equal(newOptions.first().val(), "0");
+        equal(newOptions.last().val(), "2");
     });
 
     test('TODO: Options as function that calls back with options', function() {
@@ -1077,6 +1103,39 @@ module('Radio', {
         schema = {
             options: ['Sterling', 'Lana', 'Cyril', 'Cheryl', 'Pam']
         };
+
+    test('Options as array of objects', function() {
+        var field = new editor({
+            schema: {
+                options: [
+                    {
+                        val: 0,
+                        label: "Option 1"
+                    },
+                    {
+                        val: 1,
+                        label: "Option 2"
+                    },
+                    {
+                        val: 2,
+                        label: "Option 3"
+                    }
+                ]
+            }
+        }).render();
+
+        var radios = field.$el.find("input[type=radio]");
+        var labels = field.$el.find("label");
+
+        equal(radios.length, 3);
+        equal(radios.length, labels.length);
+
+        equal(labels.first().html(), "Option 1");
+        equal(labels.last().html(), "Option 3");
+
+        equal(radios.first().val(), "0");
+        equal(radios.last().val(), "2");
+    });
 
     test('Default value', function() {
         var field = new editor({
@@ -1347,6 +1406,39 @@ module('Checkboxes', {
         schema = {
             options: ['Sterling', 'Lana', 'Cyril', 'Cheryl', 'Pam', 'Doctor Krieger']
         };
+
+    test('Options as array of objects', function() {
+        var field = new editor({
+            schema: {
+                options: [
+                    {
+                        val: 0,
+                        label: "Option 1"
+                    },
+                    {
+                        val: 1,
+                        label: "Option 2"
+                    },
+                    {
+                        val: 2,
+                        label: "Option 3"
+                    }
+                ]
+            }
+        }).render();
+
+        var checkboxes = field.$el.find("input[type=checkbox]");
+        var labels = field.$el.find("label");
+
+        equal(checkboxes.length, 3);
+        equal(checkboxes.length, labels.length);
+
+        equal(labels.first().html(), "Option 1");
+        equal(labels.last().html(), "Option 3");
+
+        equal(checkboxes.first().val(), "0");
+        equal(checkboxes.last().val(), "2");
+    });
 
     test('Default value', function() {
         var field = new editor({


### PR DESCRIPTION
Select and other editors dealing with lists take an options object that
define available choices.
The options object handles both HTML element value and the label.

This patch makes the editors handle integer 0 correctly as a value for
the list elements.

TL; DR:

``` javascript
new editors.Select({
  schema: { options: [
    val: 0,
    label: "I should have 0 as value"
  ]}
})
```

This doesn't work, the integer 0 is falsy, so it's doesn't get picked up.
The resulting <option> element will have a value attribute without a value,
making the value end up as "" when queried for in the DOM.
