### PR TITLE
Text-only error and help messages support

### DIFF
--- a/src/field.js
+++ b/src/field.js
@@ -93,7 +93,7 @@ Form.Field = (function() {
       //Set help text
       this.$help = $('.bbf-tmp-help', $field).parent();
       this.$help.empty();
-      if (this.schema.help) this.$help.html(this.schema.help);
+      if (this.schema.help) this.form.options.htmlHelp ? this.$help.html(this.schema.help) : this.$help.text(this.schema.help);
       
       //Add custom CSS class names
       if (this.schema.fieldClass) $field.addClass(this.schema.fieldClass);
@@ -159,7 +159,7 @@ Form.Field = (function() {
 
       this.$el.addClass(errClass);
       
-      if (this.$help) this.$help.html(msg);
+      if (helpMsg) this.form.options.htmlHelp ? this.$help.html(helpMsg) : this.$help.text(helpMsg);
     },
     
     /**
@@ -176,7 +176,7 @@ Form.Field = (function() {
       
         //Reset help text if available
         var helpMsg = this.schema.help;
-        if (helpMsg) this.$help.html(helpMsg);
+        if (helpMsg) this.form.options.htmlHelp ? this.$help.html(helpMsg) : this.$help.text(helpMsg);
       }
     },
 

--- a/src/form.js
+++ b/src/form.js
@@ -44,7 +44,9 @@ var Form = (function() {
       options = _.extend({
         template: 'form',
         fieldsetTemplate: 'fieldset',
-        fieldTemplate: 'field'
+        fieldTemplate: 'field',
+        htmlHelp: true,
+        htmlErrors: true
       }, options);
 
       //Determine fieldsets


### PR DESCRIPTION
Help and validation errors could contain html markup, that will be added to form. Such functionality not always required and could break markup, if validation message contains data from input that could accept </> characters. Maybe with some applications we can have an XSS attack vector here.

I've added following options to Form options object:
htmlHelp : true
htmlErrors : true
New options set to 'true' by default to preserve current code behavior, but I think the best way is to set at least htmlErrors to 'false' by default
