### PR TITLE
setError and clearError on Form.editors.List.Item

### DIFF
--- a/src/editors/list.js
+++ b/src/editors/list.js
@@ -352,16 +352,26 @@
      * Show a validation error
      */
     setError: function(err) {
-      this.$el.addClass(Form.classNames.error);
-      this.$el.attr('title', err.message);
+      if (_.isFunction(this.editor.setError)) {
+        this.editor.setError(err);
+      } else {
+        this.$el.addClass(Form.classNames.error);
+        this.$el.attr('title', err.message);
+      }
     },
 
     /**
      * Hide validation errors
      */
     clearError: function() {
-      this.$el.removeClass(Form.classNames.error);
-      this.$el.attr('title', null);
+      if (_.isFunction(this.editor.setError)) {
+        if (_.isFunction(this.editor.clearError)) {
+          this.editor.clearError();
+        }
+      } else {
+        this.$el.removeClass(Form.classNames.error);
+        this.$el.attr('title', null);
+      }
     }
   });
 


### PR DESCRIPTION
Allow items used in a list to "override" setError and clearError.

I don't necessarily think this is the code you'll want to pull, but I wanted to point out the issue I'm having trying to override the error handling logic when validating list items.
