### PR TITLE
Add Form.setValue(key, val) option for arguments

### DIFF
--- a/src/form.js
+++ b/src/form.js
@@ -314,9 +314,16 @@ var Form = (function() {
     
     /**
      * Update field values, referenced by key
-     * @param {Object} data     New values to set
+     * @param {Object|String} key     New values to set, or property to set
+     * @param val                     Value to set
      */
-    setValue: function(data) {
+    setValue: function(prop, val) {
+      var data = {};
+      if (typeof prop === 'string') {
+        data[prop] = val;
+      } else {
+        data = prop;
+      }
       for (var key in data) {
         if (_.has(this.fields, key)) {
           this.fields[key].setValue(data[key]);

--- a/test/form.js
+++ b/test/form.js
@@ -291,6 +291,12 @@ test("setValue() - updates form field values", function() {
     
     //Check fields that shouldn't have changed
     equal(form.fields.author.getValue(), 'Sterling Archer');
+    
+    //Check callig with key, val as arguments
+    form.setValue('title', 'Danger Zone 3');
+    
+    //Check changed fields
+    equal(form.fields.title.getValue(), 'Danger Zone 3');
 });
 
 test("setValue() - ignore attributes not in form", function() {


### PR DESCRIPTION
Allow setValue to be called with a property and value as arguments, akin to Backbone.Model.set
