### PR TITLE
Fixes #135: Updated Hidden type to specify tagName

### DIFF
--- a/src/editors.js
+++ b/src/editors.js
@@ -395,6 +395,8 @@ Form.editors = (function() {
   //HIDDEN
   editors.Hidden = editors.Base.extend({
     
+    tagName: 'input'
+    
     defaultValue: '',
 
     initialize: function(options) {


### PR DESCRIPTION
- Ensures that the Hidden type uses an input tag instead of a div.
- Adding tagName seemed more appropriate than extending Text instead of Base.
