### PR TITLE
Allow use of required validator with checkbox fields

### DIFF
--- a/src/editors.js
+++ b/src/editors.js
@@ -368,7 +368,7 @@ Form.editors = (function() {
     },
     
     getValue: function() {
-      return this.$el.prop('checked');
+      return this.$el.prop('checked') || undefined;
     },
     
     setValue: function(value) {

--- a/test/editors.js
+++ b/test/editors.js
@@ -639,7 +639,7 @@ module('Checkbox', {
     test('Default value', function() {
         var field = new editor().render();
 
-        deepEqual(field.getValue(), false);
+        deepEqual(field.getValue(), undefined);
     });
 
     test('Custom value', function() {
@@ -666,7 +666,7 @@ module('Checkbox', {
         deepEqual($(field.el).attr('type'), 'checkbox');
     });
     
-    test("getValue() - returns boolean", function() {
+    test("getValue() - returns true if checked, or undefined", function() {
         var field1 = new editor({
             value: true
         }).render();
@@ -676,7 +676,7 @@ module('Checkbox', {
         }).render();
         
         deepEqual(field1.getValue(), true);
-        deepEqual(field2.getValue(), false);
+        deepEqual(field2.getValue(), undefined);
     });
     
     test("setValue() - updates the input value", function() {


### PR DESCRIPTION
Set return value of unchecked checkbox to undefined so that it can fail
a required validator if not checked.
