### PR TITLE
Make Form.Field template rendering context overrideable

### DIFF
--- a/src/field.js
+++ b/src/field.js
@@ -51,6 +51,23 @@ Form.Field = (function() {
       }, options.schema);
     },
 
+
+    /**
+     * Provides the context for rendering the field
+     * Override this to extend the default context
+     */
+    renderingContext: function(schema, editor) {
+      return {
+        key: this.key,
+        title: schema.title,
+        id: editor.id,
+        type: schema.type,
+        editor: '<b class="bbf-tmp-editor"></b>',
+        help: '<b class="bbf-tmp-help"></b>'
+      };
+    },
+
+
     /**
      * Renders the field
      */
@@ -78,14 +95,7 @@ Form.Field = (function() {
       var editor = this.editor = helpers.createEditor(schema.type, options);
       
       //Create the element
-      var $field = $(templates[schema.template]({
-        key: this.key,
-        title: schema.title,
-        id: editor.id,
-        type: schema.type,
-        editor: '<b class="bbf-tmp-editor"></b>',
-        help: '<b class="bbf-tmp-help"></b>'
-      }));
+      var $field = $(templates[schema.template](this.renderingContext(schema, editor)));
       
       //Render editor
       $field.find('.bbf-tmp-editor').replaceWith(editor.render().el);


### PR DESCRIPTION
Extract the current inline context into a method, renderingContext().
In this way, by extend()ing or overriding Form.Field.renderingContext,
one can use other data in the template.

I believe this would address the concerns in https://github.com/powmedia/backbone-forms/issues/120
