### PR TITLE
Fix AMD wrapper for templates

### DIFF
--- a/scripts/build-templates/standalone-template.amd.js
+++ b/scripts/build-templates/standalone-template.amd.js
@@ -4,7 +4,7 @@
  * - "data-type" attributes are required.
  * - The main placeholder tags such as the following are required: fieldsets, fields
  */
-define(['jquery', 'underscore', 'backbone'], function($, _, Backbone) {
+define(['jquery', 'underscore', 'backbone', 'backbone-forms'], function($, _, Backbone) {
   var Form = Backbone.Form;
 
   {{body}}


### PR DESCRIPTION
I added 'backbone-forms' as a dependency to the AMD wrapper for templates to prevent race conditions when using the bootstrap template. Without it, you might see a 'Form is undefined' error.
