### PR TITLE
Empty and non-matching field should fail match validation

### DIFF
--- a/src/validators.js
+++ b/src/validators.js
@@ -92,8 +92,8 @@ Form.validators = (function() {
         message: Form.helpers.createTemplate(options.message, options)
       };
       
-      //Don't check empty values (add a 'required' validator for this)
-      if (value === null || value === undefined || value === '') return;
+      //Don't check null/undefined values
+      if (value === null || value === undefined) return;
       
       if (value != attrs[options.field]) return err;
     }

--- a/test/validators.js
+++ b/test/validators.js
@@ -148,7 +148,6 @@
   });
   
   test('passes empty values', function() {
-    equal(fn(''), undefined)
     equal(fn(null), undefined)
     equal(fn(undefined), undefined)
   })
@@ -169,6 +168,11 @@
     };
     
     var err = fn('foo', attrs)
+    
+    equal(err.type, 'match')
+    equal(err.message, 'Must match field "confirm"')
+
+    err = fn('', attrs)
     
     equal(err.type, 'match')
     equal(err.message, 'Must match field "confirm"')


### PR DESCRIPTION
If it is empty, a field with `match` validation type passes validation even though its value does not match. The field is in a known invalid state and so validation should fail.
