### PR TITLE
Use predefined, abstracted ModalAdapter...

### DIFF
--- a/src/editors/list.js
+++ b/src/editors/list.js
@@ -499,7 +499,7 @@
         data: this.value
       });
 
-      var ModalAdapter = (this.options.schema.modalAdapter ||
+      var ModalAdapter = (this.schema.modalAdapter ||
                           editors.List.Modal.ModalAdapter),
         modal = this.modal = new ModalAdapter({
         content: form,


### PR DESCRIPTION
... rather than duplicate, hardcoded Backbone.BootstrapModal & allow customization in the schema.

Not added more tests as test file doesn't test modal stuff yet.
