### PR TITLE
Apply `require` validator for fields type of List. 

### DIFF
--- a/src/editors/list.js
+++ b/src/editors/list.js
@@ -228,9 +228,15 @@
      */
     validate: function() {
       if (!this.validators) return null;
+      
+      // call validate of Base editor
+      var errors = editors.Base.prototype.validate.call(this);
 
-      //Collect errors
-      var errors = _.map(this.items, function(item) {
+      // if any errors return them
+      if (errors) return errors;
+
+      //Collect items errors
+      errors = _.map(this.items, function(item) {
         return item.validate();
       });
 

--- a/src/validators.js
+++ b/src/validators.js
@@ -29,7 +29,7 @@ Form.validators = (function() {
         message: Form.helpers.createTemplate(options.message, options)
       };
       
-      if (value === null || value === undefined || value === false || value === '') return err;
+      if (value === null || value === undefined || value === false || value === '' || value.length === 0) return err;
     };
   };
   


### PR DESCRIPTION
I'm not sure if this is appropriate or if this change follows project general conventions but here we have some fixes. Now you can add validators to fields type of `List` and they are actually applied (called). In addition, `require` validator checks if value's `length` attribute is equal to `0`. 
