### PR TITLE
Fixing change events

### DIFF
--- a/src/editors/number.js
+++ b/src/editors/number.js
@@ -39,7 +39,7 @@ Form.editors.Number = Form.editors.Text.extend({
     //Get the whole new value so that we can prevent things like double decimals points etc.
     var newVal = this.$el.val() + String.fromCharCode(event.charCode);
 
-    var numeric = /^-?[0-9]*\.?[0-9]*?$/.test(newVal);
+    var numeric = /^-?[0-9]*\.?[0-9]*$/.test(newVal);
 
     if (numeric) {
       delayedDetermineChange();

--- a/src/editors/number.js
+++ b/src/editors/number.js
@@ -39,7 +39,7 @@ Form.editors.Number = Form.editors.Text.extend({
     //Get the whole new value so that we can prevent things like double decimals points etc.
     var newVal = this.$el.val() + String.fromCharCode(event.charCode);
 
-    var numeric = /^[0-9]*\.?[0-9]*?$/.test(newVal);
+    var numeric = /^-?[0-9]*\.?[0-9]*?$/.test(newVal);
 
     if (numeric) {
       delayedDetermineChange();

--- a/src/editors/number.js
+++ b/src/editors/number.js
@@ -8,7 +8,8 @@ Form.editors.Number = Form.editors.Text.extend({
   defaultValue: 0,
 
   events: _.extend({}, Form.editors.Text.prototype.events, {
-    'keypress': 'onKeyPress'
+    'keypress': 'onKeyPress',
+    'input':    'determineChange'
   }),
 
   initialize: function(options) {

--- a/src/editors/text.js
+++ b/src/editors/text.js
@@ -78,6 +78,7 @@ Form.editors.Text = Form.Editor.extend({
    */
   setValue: function(value) {
     this.$el.val(value);
+    this.previousValue = this.$el.val();
   },
 
   focus: function() {

--- a/test/editors/number.js
+++ b/test/editors/number.js
@@ -110,8 +110,8 @@
     editor.on('change', spy);
 
     // Pressing a valid key
-    editor.$el.keypress($.Event("keypress", { charCode: 48 }));
-    editor.$el.val('0');
+    editor.$el.keypress($.Event("keypress", { charCode: 49 }));
+    editor.$el.val('1');
 
     stop();
     setTimeout(function(){
@@ -146,6 +146,26 @@
           start();
         }, 0);
       }, 0);
+    }, 0);
+  });
+
+  test("'change' event - isn't triggered if the value doesn't change", function() {
+    var editor = this.editor;
+
+    var spy = this.sinon.spy();
+
+    editor.on('change', spy);
+
+    // Number is 0 by default, pressing 0 again
+    editor.$el.keypress($.Event("keypress", { charCode: 48 }));
+    editor.$el.val('0');
+
+    stop();
+    setTimeout(function(){
+
+      ok(spy.callCount == 0);
+      start();
+
     }, 0);
   });
 

--- a/test/editors/number.js
+++ b/test/editors/number.js
@@ -163,10 +163,23 @@
     stop();
     setTimeout(function(){
 
-      ok(spy.callCount == 0);
+      ok(spy.callCount === 0);
       start();
 
     }, 0);
+  });
+
+  test("'change' event - is triggered when clicking the spinner ('input' event)", function() {
+    var editor = this.editor;
+
+    var spy = this.sinon.spy();
+
+    editor.on('change', spy);
+
+    editor.$el.val('10');
+    editor.$el.trigger('input');
+
+    ok(spy.callCount === 1);
   });
 
 

--- a/test/editors/text.js
+++ b/test/editors/text.js
@@ -21,6 +21,14 @@
     equal($(editor.el).attr('type'), 'tel');
   });
 
+  test("previousValue should equal initial value", function() {
+    var editor = new Editor({
+      value: 'Test'
+    }).render();
+
+    equal(editor.previousValue, 'Test');
+  });
+
 
 
   module('Text#getValue()');
@@ -61,6 +69,14 @@
 
     equal(editor.getValue(), 'foobar');
     equal($(editor.el).val(), 'foobar');
+  });
+
+  test("previousValue should equal set value", function() {
+    var editor = new Editor().render();
+
+    editor.setValue('Test');
+
+    equal(editor.previousValue, 'Test');
   });
 
 


### PR DESCRIPTION
This fixes a few bugs:
1. When setting a value the "previousValue" for determining when to fire change events isn't updated. (Bug https://github.com/powmedia/backbone-forms/issues/220)
2. When pressing 0 in an empty number field, it shouldn't fire a change event because it didn't change.
3. Emit "change" events when clicking number spinner (bug https://github.com/powmedia/backbone-forms/issues/214)
4. Allowing negative sign in numbers, since we can get there by the spinners and it's part of a valid number. Restriction to positive numbers can be done in validations (see pull https://github.com/powmedia/backbone-forms/pull/163)