### PR TITLE
Handle cases where a field value is a model

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -28,7 +28,7 @@ Form.Editor = Form.editors.Base = Backbone.View.extend({
       this.value = this.model.get(options.key);
 
       //Handle cases where the value is itself a model
-      if (typeof this.value == 'object') {
+      if (this.value instanceof Backbone.Model) {
         this.value = this.value.id
       }
     }

--- a/src/editor.js
+++ b/src/editor.js
@@ -26,6 +26,11 @@ Form.Editor = Form.editors.Base = Backbone.View.extend({
       this.model = options.model;
 
       this.value = this.model.get(options.key);
+
+      //Handle cases where the value is itself a model
+      if (typeof this.value == 'object') {
+        this.value = this.value.id
+      }
     }
     else if (options.value) {
       this.value = options.value;

--- a/src/editors/select.js
+++ b/src/editors/select.js
@@ -82,6 +82,8 @@ Form.editors.Select = Form.editors.Base.extend({
     var $select = this.$el,
         html;
 
+    this.options = options;
+
     html = this._getOptionsHtml(options);
 
     //Insert options


### PR DESCRIPTION
This pull request fixes a problem where, when the value of a field is a model, the field editor does not set the initial value correctly.

Some background:

I am using [Backbone Relational](http://backbonerelational.org/), and so my models can contain other models.

For example, let's say I have a Person model and a Location model, and each Person has a Location. The JSON would look like this:

``` json
{"id":1,"name":"Fred Flintstone","location":{"id":123,"name":"Bedrock"}}
```

I want to have a Backbone Form with a Select editor to change the Person's Location. No problem, I just create a collection of Locations and set my Person schema like so:

``` javascript
schema: {
    location: {
        type: 'Select',
        options: locationsCollection
    }
}
```

This correctly renders the select box, and the form submits and saves the new location value.

The only problem is, when the form is first displayed, the select box does not default to the current location value, as it tries to look for an option that equals the model object (which is impossible), instead of its `id`.

This is a simple fix for that problem.
