### PR TITLE
changing from charCode to keyCode in number editor keypress handler

### DIFF
--- a/src/editors/number.js
+++ b/src/editors/number.js
@@ -29,14 +29,14 @@ Form.editors.Number = Form.editors.Text.extend({
           }, 0);
         };
 
-    //Allow backspace
-    if (event.charCode === 0) {
+    //Allow special keys
+    if (event.charCode === 0 || event.which === 0) {
       delayedDetermineChange();
       return;
     }
 
     //Get the whole new value so that we can prevent things like double decimals points etc.
-    var newVal = this.$el.val() + String.fromCharCode(event.charCode);
+    var newVal = this.$el.val() + String.fromCharCode(event.keyCode);
 
     var numeric = /^[0-9]*\.?[0-9]*?$/.test(newVal);
 


### PR DESCRIPTION
fixes issue [228: Number editor doesn't allow editing numbers (IE < 9)](https://github.com/powmedia/backbone-forms/issues/228)
