### PR TITLE
HTML5 input type=numeric "change" event fix

### DIFF
--- a/src/editors/number.js
+++ b/src/editors/number.js
@@ -8,7 +8,8 @@ Form.editors.Number = Form.editors.Text.extend({
   defaultValue: 0,
 
   events: _.extend({}, Form.editors.Text.prototype.events, {
-    'keypress': 'onKeyPress'
+    'keypress': 'onKeyPress',
+    'change': 'onKeyPress'
   }),
 
   initialize: function(options) {
@@ -36,7 +37,10 @@ Form.editors.Number = Form.editors.Text.extend({
     }
 
     //Get the whole new value so that we can prevent things like double decimals points etc.
-    var newVal = this.$el.val() + String.fromCharCode(event.charCode);
+    var newVal = this.$el.val()
+    if( event.charCode != undefined ) {
+      newVal = newVal + String.fromCharCode(event.charCode);
+    }
 
     var numeric = /^[0-9]*\.?[0-9]*?$/.test(newVal);
 


### PR DESCRIPTION
The editor correctly fires the "change" event if the user types
characters in the field with the keyboard but if the user uses the
up/down arrows to change the numeric value the "change" event would not
fire. I know doubling up onKeyPress isn't ideal but it solves the
problem.
