### PR TITLE
Don't overwrite step parameter in number editor

### DIFF
--- a/src/editors/number.js
+++ b/src/editors/number.js
@@ -14,8 +14,15 @@ Form.editors.Number = Form.editors.Text.extend({
   initialize: function(options) {
     Form.editors.Text.prototype.initialize.call(this, options);
 
+    var schema = this.schema;
+
     this.$el.attr('type', 'number');
-    this.$el.attr('step', 'any');
+
+    if (!schema || !schema.editorAttrs || !schema.editorAttrs.step) {
+      // provide a default for `step` attr,
+      // but don't overwrite if already specified
+      this.$el.attr('step', 'any');
+    }
   },
 
   /**

--- a/test/editors/number.js
+++ b/test/editors/number.js
@@ -43,6 +43,28 @@
     same(editor.$el.attr('type'), 'number');
   });
 
+  test('Sets step="any" by default', function() {
+    var editor = new Editor().render();
+
+    same(editor.$el.attr('step'), 'any');
+  });
+
+  test('Allows setting a custom step value', function() {
+    var editor = new Editor({
+      schema: { editorAttrs: { step: 5 }}
+    }).render();
+
+    same(editor.$el.attr('step'), '5');
+  });
+
+  test('Allows setting a custom minimum value', function() {
+    var editor = new Editor({
+      schema: { editorAttrs: { min: 150 }}
+    }).render();
+
+    same(editor.$el.attr('min'), '150');
+  });
+
   test("TODO: Restricts non-numeric characters", function() {
     ok(1);
   });


### PR DESCRIPTION
Hi! I noticed the input type=number editor was always overwriting the step value with "any" even if another value was provided in editorAttrs. This commit makes it not overwrite a step value if provided. It includes the change to src file and tests for default ("any") step and custom step value.

It's my first pull request ever so I apologize in advance if anything is wrong. I didn't include any generated files since I wasn't sure whether you wanted them and for some reason my generated files had other changes beyond my own (I might have not had the right files from the submodule?). Hope it's serviceable!
