### PR TITLE
Return the form instance from remove with arguments passed thru

### DIFF
--- a/src/form.js
+++ b/src/form.js
@@ -1,4 +1,3 @@
-
 //==================================================================================================
 //FORM
 //==================================================================================================
@@ -424,7 +423,7 @@ var Form = Backbone.View.extend({
       field.remove();
     });
 
-    Backbone.View.prototype.remove.call(this);
+    return Backbone.View.prototype.remove.apply(this, arguments);
   }
 
 }, {


### PR DESCRIPTION
The signature for [Backbone.View#remove](https://github.com/jashkenas/backbone/blob/1.0.0/backbone.js#L1022) should return the view instance that allows chaining View method calls. This fixes it.
