### PR TITLE
Adds 'with' option to schema for specifying the Field object constructor to build the field with

### DIFF
--- a/src/form.js
+++ b/src/form.js
@@ -6,7 +6,7 @@ var Form = Backbone.View.extend({
 
   /**
    * Constructor
-   * 
+   *
    * @param {Object} [options.schema]
    * @param {Backbone.Model} [options.model]
    * @param {Object} [options.data]
@@ -100,7 +100,7 @@ var Form = Backbone.View.extend({
     var options = {
       form: this,
       key: key,
-      schema: schema,
+      schema: schema || {},
       idPrefix: this.idPrefix
     };
 
@@ -112,7 +112,9 @@ var Form = Backbone.View.extend({
       options.value = null;
     }
 
-    var field = new this.Field(options);
+    var fieldConstructor = options.schema.field || this.Field;
+
+    var field = new fieldConstructor(options);
 
     this.listenTo(field.editor, 'all', this.handleEditorEvent);
 
@@ -219,7 +221,7 @@ var Form = Backbone.View.extend({
 
     //Set the main element
     this.setElement($form);
-    
+
     //Set class
     $form.addClass(this.className);
 
@@ -304,7 +306,7 @@ var Form = Backbone.View.extend({
     }, options);
 
     this.model.set(this.getValue(), setOptions);
-    
+
     if (modelError) return modelError;
   },
 
@@ -434,8 +436,8 @@ var Form = Backbone.View.extend({
   ', null, this.templateSettings),
 
   templateSettings: {
-    evaluate: /<%([\s\S]+?)%>/g, 
-    interpolate: /<%=([\s\S]+?)%>/g, 
+    evaluate: /<%([\s\S]+?)%>/g,
+    interpolate: /<%=([\s\S]+?)%>/g,
     escape: /<%-([\s\S]+?)%>/g
   },
 

--- a/test/form.js
+++ b/test/form.js
@@ -347,6 +347,21 @@ test('creates a new instance of the Field defined on the form - without model', 
   same(optionsArg.value, 'John');
 });
 
+test('allows for overriding field constructor via schema', function () {
+  var CustomMockField = this.MockField.extend();
+
+  var form = new Form;
+
+  this.sinon.spy(CustomMockField.prototype, 'initialize');
+
+  var field = form.createField('name', {
+    type: 'Text',
+    field: CustomMockField
+  });
+
+  same(field instanceof CustomMockField, true);
+});
+
 test('adds listener to all editor events', function() {
   var MockField = this.MockField;
 


### PR DESCRIPTION
Sometimes certain fields in a form require custom logic. This allows you to use different Field constructors for different fields in the schema using a `with` option like so:

``` javascript
schema: {
  name: {
    title: "Full Name",
    with: MyCoolNameField
  }
}
```

Thoughts? If this is something we'd like to merge, I'd be happy to add tests.
