### PR TITLE
Allow string input on regexp validator

### DIFF
--- a/distribution/backbone-forms.js
+++ b/distribution/backbone-forms.js
@@ -525,7 +525,7 @@ Form.validators = (function() {
       if (value === null || value === undefined || value === '') return;
       
       //Create RegExp from string if it's valid
-      if ('string' === typeof options.regexp) options.regexp = new RegExp(options.regexp);
+      if ('string' === typeof options.regexp) options.regexp = new RegExp(options.regexp, options.flags);
 
       if (!options.regexp.test(value)) return err;
     };

--- a/src/validators.js
+++ b/src/validators.js
@@ -52,6 +52,9 @@ Form.validators = (function() {
       //Don't check empty values (add a 'required' validator for this)
       if (value === null || value === undefined || value === '') return;
 
+      //Create RegExp from string if it's valid
+      if ('string' === typeof options.regexp) options.regexp = new RegExp(options.regexp, options.flags);
+
       if (!options.regexp.test(value)) return err;
     };
   };

--- a/test/validators.js
+++ b/test/validators.js
@@ -57,6 +57,11 @@
     regexp: /foo/
   });
 
+  var fnStr = Form.validators.regexp({
+    regexp : '^(foo|bar)$',
+    flags : 'i'
+  });
+
   test('passes empty values', function() {
     equal(fn(''), undefined)
     equal(fn(null), undefined)
@@ -71,6 +76,19 @@
   test('passes valid strings', function() {
     equal(fn('foo'), undefined)
     equal(fn('_foo_'), undefined)
+  })
+
+  test('fails string input', function() {
+    equal(fnStr(''), undefined)
+    equal(fnStr('food').type, 'regexp')
+    equal(fnStr('food').message, 'Invalid')
+    equal(fnStr('bars').type, 'regexp')
+    equal(fnStr('bars').message, 'Invalid')
+  })
+
+  test('passes string input', function() {
+    equal(fnStr('foo'), undefined)
+    equal(fnStr('bar'), undefined)
   })
 
 })();


### PR DESCRIPTION
This would allow RegExp validator parse a string instead of requiring the value to be an instance of RegExp. Particularly useful if the schema is transmitted as a JSON object over AJAX for example.

``` javascript
// GET /api/schema
{
    error : false,
    code : 200,
    response : {
        id : {
            type : 'Number',
            title : 'ID'
        },
        name : {
            type : 'Text',
            title : 'Name',
            validators : [
                { type : 'regexp', message : 'Not a valid name!', regexp : '^[a-zA-Z]+$' }
            ]
        }
    }
}
```
