### PR TITLE
Use Model.id instead of Model when it exists.

### DIFF
--- a/src/editors/select.js
+++ b/src/editors/select.js
@@ -89,7 +89,7 @@ Form.editors.Select = Form.editors.Base.extend({
     $select.html(html);
 
     //Select correct option
-    this.setValue(this.value);
+    this.setValue(this.value.id || this.value);
   },
 
   _getOptionsHtml: function(options) {


### PR DESCRIPTION
This solves an issue that occurs when the provided options are a Collection of data. The default value wont be set properly due to a Model being passed to setValue.
