### PR TITLE
Add ability to use a css class on fieldsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ HTML:
 <script id="formTemplate" type="text/html">
     <form>
         <h1>New User</h1>
-        
+
         <h2>Main Info</h2>
         <div data-fields="title,name,birthday"></div>
-        
+
         <h2>Account Info</h2>
         <h3>Email</h3>
         <div data-fields="email"></div>
@@ -59,7 +59,7 @@ Javascript:
 ```js
 var UserForm = Backbone.Form.extend({
     template: _.template($('#formTemplate').html()),
-    
+
     schema: {
         title:      { type: 'Select', options: ['Mr', 'Mrs', 'Ms'] },
         name:       'Text',
@@ -197,7 +197,7 @@ var form = new Backbone.Form({
         name:       'Text',
         password:   'Password'
     },
-    
+
     //Data to populate the form with
     data: {
       id: 123,
@@ -237,7 +237,7 @@ If a form has a model attached to it, the initial values are taken from the mode
 
 - **`fieldsets`**
 
-  An array of fieldsets descriptions. A fieldset is either a list of field names, or an object with `legend` and `fields` attributes. The `legend` will be inserted at the top of the fieldset inside a `<legend>` tag; the list of fields will be treated as `fields` is below. `fieldsets` takes priority over `fields`.
+  An array of fieldsets descriptions. A fieldset is either a list of field names, or an object with `legend`, `cssClass` and `fields` attributes. The `legend` will be inserted at the top of the fieldset inside a `<legend>` tag; the list of fields will be treated as `fields` is below. `fieldsets` takes priority over `fields`.
 
 - **`fields`**
 
@@ -764,11 +764,11 @@ To customise forms even further you can pass in a template to the form instance 
 <script id="formTemplate" type="text/html">
     <form>
         <h1>Edit profile</h1>
-        
+
         <h2>Name</h2>
         <div data-editors="firstName"><!-- firstName editor will be added here --></div>
         <div data-editors="lastName"><!-- lastName editor will be added here --></div>
-        
+
         <h2>Password</h2>
         <div data-editors="password">
             <div class="notes">Must be at least 7 characters:</div>

--- a/src/fieldset.js
+++ b/src/fieldset.js
@@ -23,7 +23,7 @@ Form.Fieldset = Backbone.View.extend({
 
     //Store the fields for this fieldset
     this.fields = _.pick(options.fields, schema.fields);
-    
+
     //Override defaults
     this.template = options.template || this.constructor.template;
   },
@@ -43,6 +43,7 @@ Form.Fieldset = Backbone.View.extend({
 
     //Add null legend to prevent template error
     schema.legend = schema.legend || null;
+    schema.cssClass = schema.cssClass || null;
 
     return schema;
   },
@@ -108,12 +109,12 @@ Form.Fieldset = Backbone.View.extend({
 
     Backbone.View.prototype.remove.call(this);
   }
-  
+
 }, {
   //STATICS
 
   template: _.template('\
-    <fieldset data-fields>\
+    <fieldset <% if (cssClass) { %>class="<%= cssClass %>"<% } %> data-fields>\
       <% if (legend) { %>\
         <legend><%= legend %></legend>\
       <% } %>\

--- a/src/form.js
+++ b/src/form.js
@@ -6,7 +6,7 @@ var Form = Backbone.View.extend({
 
   /**
    * Constructor
-   * 
+   *
    * @param {Object} [options.schema]
    * @param {Backbone.Model} [options.model]
    * @param {Object} [options.data]
@@ -64,7 +64,7 @@ var Form = Backbone.View.extend({
     }, this);
 
     //Create fieldsets
-    var fieldsetSchema = options.fieldsets || [selectedFields],
+    var fieldsetSchema = options.fieldsets || this.fieldsets || [selectedFields],
         fieldsets = this.fieldsets = [];
 
     _.each(fieldsetSchema, function(itemSchema) {
@@ -219,7 +219,7 @@ var Form = Backbone.View.extend({
 
     //Set the main element
     this.setElement($form);
-    
+
     //Set class
     $form.addClass(this.className);
 
@@ -312,7 +312,7 @@ var Form = Backbone.View.extend({
     }, options);
 
     this.model.set(this.getValue(), setOptions);
-    
+
     if (modelError) return modelError;
   },
 
@@ -442,8 +442,8 @@ var Form = Backbone.View.extend({
   ', null, this.templateSettings),
 
   templateSettings: {
-    evaluate: /<%([\s\S]+?)%>/g, 
-    interpolate: /<%=([\s\S]+?)%>/g, 
+    evaluate: /<%([\s\S]+?)%>/g,
+    interpolate: /<%=([\s\S]+?)%>/g,
     escape: /<%-([\s\S]+?)%>/g
   },
 

--- a/test/fieldset.js
+++ b/test/fieldset.js
@@ -72,7 +72,7 @@ module('Fieldset#createSchema', {
   }
 });
 
-test('converts an array schema into an object with legend', function() {
+test('converts an array schema into an object with legend and cssClass', function() {
   var options = {
     fields: {
       title: new Form.Field({ key: 'title' }),
@@ -85,7 +85,7 @@ test('converts an array schema into an object with legend', function() {
 
   var schema = fs.createSchema(options.schema);
 
-  same(schema, { legend:null, fields: ['title', 'author'] });
+  same(schema, { cssClass: null, legend:null, fields: ['title', 'author'] });
 });
 
 test('returns fully formed schema as is', function() {
@@ -183,6 +183,28 @@ test('with data-fields placeholder, on inner element', function() {
   same(fs.$el.html(), 'Main<b data-fields=""><field class="title"></field><field class="author"></field></b>');
 });
 
+test('has a cssClass', function() {
+  var UserForm = Backbone.Form.extend({
+      schema: {
+          title:      { type: 'Select', options: ['Mr', 'Mrs', 'Ms'] },
+          name:       'Text',
+          email:      { validators: ['required', 'email'] },
+          password:   'Password'
+      },
+
+      fieldsets: [
+        {fields: ['title', 'name'], cssClass: 'pull-right'},
+        {fields: ['email', 'password']}
+      ]
+  });
+
+  var form = new UserForm();
+
+  form.render();
+
+  same(form.$el.html(), '<fieldset class=\"pull-right\" data-fields=\"\">          <field class=\"title\"></field><field class=\"name\"></field></fieldset><fieldset data-fields=\"\">          <field class=\"email\"></field><field class=\"password\"></field></fieldset>');
+});
+
 test('with data-fields placeholder, on outermost element', function() {
   var fs = new Fieldset({
     fields: {
@@ -212,7 +234,7 @@ module('Form#remove', {
   }
 });
 
-test('removes fieldsets, fields and self', function() {  
+test('removes fieldsets, fields and self', function() {
   var fs = new Fieldset({
     fields: {
       title: new Form.Field({ key: 'title' }),
@@ -220,7 +242,7 @@ test('removes fieldsets, fields and self', function() {
     },
     schema: { legend: 'Main', fields: ['title', 'author'] }
   });
-  
+
   fs.remove();
 
   same(Form.Field.prototype.remove.callCount, 2);


### PR DESCRIPTION
Using fieldsets changes from:

    fieldsets: [
        {legend: 'fieldset 1', fields: ['name', 'othername']},
        {legend: 'fieldset 2', fields: ['password', 'password-repeat']}
    ]

to 

    fieldsets: [
        {legend: 'fieldset 1', fields: ['name', 'othername'], cssClass: 'names'},
        {legend: 'fieldset 2', fields: ['password', 'password-repeat'], cssClass: 'passwords'}
    ]