### PR TITLE
bugfix: List editor behaves wrongly when calling setValue() more than once

### DIFF
--- a/src/editors/extra/list.js
+++ b/src/editors/extra/list.js
@@ -70,7 +70,16 @@
         if (!this.Editor.isAsync) this.addItem();
       }
 
+      //Save a copy of the pre-exising element, if exists
+      var domReferencedElement = this.el;
+
       this.setElement($el);
+
+      //In case of there was a pre-existing element already placed in the DOM, then update it
+      if (domReferencedElement) {
+        $(domReferencedElement).replaceWith(this.el);
+      }
+
       this.$el.attr('id', this.id);
       this.$el.attr('name', this.key);
             
@@ -192,6 +201,7 @@
     },
 
     setValue: function(value) {
+      this.items = [];
       this.value = value;
       this.render();
     },

--- a/test/editors/extra/list.js
+++ b/test/editors/extra/list.js
@@ -87,6 +87,16 @@ var same = deepEqual;
         same(list.getValue(), ['a', 'b', 'c']);
     });
 
+    test('setValue() - updates input value - more than once', function() {
+        var list = new List().render();
+
+        list.setValue(['a', 'b', 'c']);
+        same(list.getValue(), ['a', 'b', 'c']);
+
+        list.setValue(['d', 'e', 'f']);
+        same(list.getValue(), ['d', 'e', 'f']);
+    });
+
     test('validate() - returns validation errors', function() {
         var list = new List({
             schema: { validators: ['required', 'email'] },


### PR DESCRIPTION
It was accumulating elements on each call, apart of that, the render() method also wasn't refreshing the DOM after the first call.

The way to reproduce is simple..
```
// given an exisiting and already rendered form...
form.setValue({ a_list_propery: ['a', 'b'] });
```
The form was not only accumulating elements, but also not refreshing the view.

I hope this could reach the trunk,
Thanks,