### PR TITLE
Allow NestedModel and Object editors' form options to be extended/overridden.

### DIFF
--- a/src/editors/nestedmodel.js
+++ b/src/editors/nestedmodel.js
@@ -11,12 +11,12 @@ Form.editors.NestedModel = Form.editors.Object.extend({
     Form.editors.Base.prototype.initialize.call(this, options);
 
     if (!this.form) throw new Error('Missing required option "form"');
-    if (!options.schema.model) throw new Error('Missing required "schema.model" option for NestedModel editor');
+    if (!this.schema.model) throw new Error('Missing required "schema.model" option for NestedModel editor');
   },
 
   render: function() {
-    //Get the constructor for creating the nested form; i.e. the same constructor as used by the parent form
-    var NestedForm = this.form.constructor;
+    //Get the constructor for creating the nested form; by default the same constructor as used by the parent form
+    var NestedForm = this.schema.formClass || this.form.constructor;
 
     var data = this.value || {},
         key = this.key,
@@ -25,11 +25,13 @@ Form.editors.NestedModel = Form.editors.Object.extend({
     //Wrap the data in a model if it isn't already a model instance
     var modelInstance = (data.constructor === nestedModel) ? data : new nestedModel(data);
 
-    this.nestedForm = new NestedForm({
+    var formOptions = _.extend({
       model: modelInstance,
       idPrefix: this.id + '_',
-      fieldTemplate: 'nestedField'
-    });
+      Field: NestedForm.NestedField
+    }, _.result(this.schema, 'formOptions') || {});
+
+    this.nestedForm = new NestedForm(formOptions);
 
     this._observeFormEvents();
 

--- a/src/editors/object.js
+++ b/src/editors/object.js
@@ -26,15 +26,16 @@ Form.editors.Object = Form.editors.Base.extend({
 
   render: function() {
     //Get the constructor for creating the nested form; i.e. the same constructor as used by the parent form
-    var NestedForm = this.form.constructor;
+    var NestedForm = this.schema.formClass || this.form.constructor;
 
-    //Create the nested form
-    this.nestedForm = new NestedForm({
+    var formOptions = _.extend({
       schema: this.schema.subSchema,
       data: this.value,
       idPrefix: this.id + '_',
       Field: NestedForm.NestedField
-    });
+    }, _.result(this.schema, 'formOptions') || {});
+
+    this.nestedForm = new NestedForm(formOptions);
 
     this._observeFormEvents();
 


### PR DESCRIPTION
I wanted to be able to override the fields rendered and template used by the nested form.

Contrived example:

``` javascript
new Backbone.Form({
  schema: {
    address: {
      type: "NestedModel",
      model: Address,
      formOptions: {
        template: JST["address_form"],
        fields: ["street_address", "locality", "postal_code", "region", "country"]
      }
    }
  }
});
```
