### PR TITLE
Support backbonejs greater than 1.0.0 in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
   
   "dependencies": {
     
-    "backbone": "~1.0.0"
+    "backbone": ">=1.0.0"
     
   },
   


### PR DESCRIPTION
Using `~1.0.0` is equivalent to `>= 1.0.0-0` `< 1.1.0-0`
I'm pretty sure this should either be `~1` meaning `>= 1.0.0` `< 2.0.0` or just `>=1.0.0` depending on what you want to support.

https://github.com/isaacs/node-semver#ranges
