### PR TITLE
don't clobber editor defaultValue by setting options.value to 'null'

### DIFF
--- a/src/editors/extra/list.js
+++ b/src/editors/extra/list.js
@@ -2,7 +2,7 @@
 
   /**
    * List editor
-   * 
+   *
    * An array editor. Creates a list of other editor items.
    *
    * Special options:
@@ -14,7 +14,7 @@
     events: {
       'click [data-action="add"]': function(event) {
         event.preventDefault();
-        this.addItem(null, true);
+        this.addItem(undefined, true);
       }
     },
 
@@ -73,9 +73,9 @@
       this.setElement($el);
       this.$el.attr('id', this.id);
       this.$el.attr('name', this.key);
-            
+
       if (this.hasFocus) this.trigger('blur', this);
-      
+
       return this;
     },
 
@@ -97,11 +97,11 @@
         Editor: this.Editor,
         key: this.key
       }).render();
-      
+
       var _addItem = function() {
         self.items.push(item);
         self.$list.append(item.el);
-        
+
         item.editor.on('all', function(event) {
           if (event === 'change') return;
 
@@ -135,11 +135,11 @@
             self.trigger('blur', self);
           }, 0);
         }, self);
-        
+
         if (userInitiated || value) {
           item.addEventTriggered = true;
         }
-        
+
         if (userInitiated) {
           self.trigger('add', self, item.editor);
           self.trigger('change', self);
@@ -156,7 +156,7 @@
         _addItem();
         item.editor.focus();
       }
-      
+
       return item;
     },
 
@@ -173,7 +173,7 @@
 
       this.items[index].remove();
       this.items.splice(index, 1);
-      
+
       if (item.addEventTriggered) {
         this.trigger('remove', this, item.editor);
         this.trigger('change', this);
@@ -195,18 +195,18 @@
       this.value = value;
       this.render();
     },
-    
+
     focus: function() {
       if (this.hasFocus) return;
 
       if (this.items[0]) this.items[0].editor.focus();
     },
-    
+
     blur: function() {
       if (!this.hasFocus) return;
 
       var focusedItem = _.find(this.items, function(item) { return item.editor.hasFocus; });
-      
+
       if (focusedItem) focusedItem.editor.blur();
     },
 
@@ -218,10 +218,10 @@
 
       Form.editors.Base.prototype.remove.call(this);
     },
-    
+
     /**
      * Run validation
-     * 
+     *
      * @return {Object|Null}
      */
     validate: function() {
@@ -295,7 +295,7 @@
 
     render: function() {
       var $ = Backbone.$;
-      
+
       //Create editor
       this.editor = new this.Editor({
         key: this.key,
@@ -313,7 +313,7 @@
 
       //Replace the entire element so there isn't a wrapper tag
       this.setElement($el);
-        
+
       return this;
     },
 
@@ -324,11 +324,11 @@
     setValue: function(value) {
       this.editor.setValue(value);
     },
-    
+
     focus: function() {
       this.editor.focus();
     },
-    
+
     blur: function() {
       this.editor.blur();
     },
@@ -397,7 +397,7 @@
 
 
   /**
-   * Base modal object editor for use with the List editor; used by Object 
+   * Base modal object editor for use with the List editor; used by Object
    * and NestedModal list types
    */
   Form.editors.List.Modal = Form.editors.Base.extend({
@@ -416,9 +416,9 @@
      */
     initialize: function(options) {
       options = options || {};
-      
+
       Form.editors.Base.prototype.initialize.call(this, options);
-      
+
       //Dependencies
       if (!Form.editors.List.Modal.ModalAdapter) throw new Error('A ModalAdapter is required');
 
@@ -467,7 +467,7 @@
      * Function which returns a generic string representation of an object
      *
      * @param {Object} value
-     * 
+     *
      * @return {String}
      */
     itemToString: function(value) {
@@ -504,7 +504,7 @@
 
       //If there's a specified toString use that
       if (schema.itemToString) return schema.itemToString(value);
-      
+
       //Otherwise use the generic method or custom overridden method
       return this.itemToString(value);
     },
@@ -529,7 +529,7 @@
       this.trigger('focus', this);
 
       modal.on('cancel', this.onModalClosed, this);
-      
+
       modal.on('ok', _.bind(this.onModalSubmitted, this));
     },
 
@@ -553,7 +553,7 @@
       this.renderSummary();
 
       if (isNew) this.trigger('readyToAdd');
-      
+
       this.trigger('change', this);
 
       this.onModalClosed();
@@ -577,16 +577,16 @@
     setValue: function(value) {
       this.value = value;
     },
-    
+
     focus: function() {
       if (this.hasFocus) return;
 
       this.openEditor();
     },
-    
+
     blur: function() {
       if (!this.hasFocus) return;
-      
+
       if (this.modal) {
         this.modal.trigger('cancel');
       }
@@ -601,7 +601,7 @@
     //Defaults to BootstrapModal (http://github.com/powmedia/backbone.bootstrap-modal)
     //Can be replaced with another adapter that implements the same interface.
     ModalAdapter: Backbone.BootstrapModal,
-    
+
     //Make the wait list for the 'ready' event before adding the item to the list
     isAsync: true
   });
@@ -644,7 +644,7 @@
 
       //If there's a specified toString use that
       if (schema.itemToString) return schema.itemToString(value);
-      
+
       //Otherwise use the model
       return new (schema.model)(value).toString();
     }

--- a/src/form.js
+++ b/src/form.js
@@ -12,7 +12,7 @@ var Form = Backbone.View.extend({
 
   /**
    * Constructor
-   * 
+   *
    * @param {Object} [options.schema]
    * @param {Backbone.Model} [options.model]
    * @param {Object} [options.data]
@@ -116,7 +116,7 @@ var Form = Backbone.View.extend({
     } else if (this.data) {
       options.value = this.data[key];
     } else {
-      options.value = null;
+      options.value = undefined;
     }
 
     var field = new this.Field(options);
@@ -235,7 +235,7 @@ var Form = Backbone.View.extend({
 
     //Set the main element
     this.setElement($form);
-    
+
     //Set class
     $form.addClass(this.className);
 
@@ -328,7 +328,7 @@ var Form = Backbone.View.extend({
     }, options);
 
     this.model.set(this.getValue(), setOptions);
-    
+
     if (modelError) return modelError;
   },
 
@@ -463,8 +463,8 @@ var Form = Backbone.View.extend({
   ', null, this.templateSettings),
 
   templateSettings: {
-    evaluate: /<%([\s\S]+?)%>/g, 
-    interpolate: /<%=([\s\S]+?)%>/g, 
+    evaluate: /<%([\s\S]+?)%>/g,
+    interpolate: /<%=([\s\S]+?)%>/g,
     escape: /<%-([\s\S]+?)%>/g
   },
 

--- a/test/editor.js
+++ b/test/editor.js
@@ -30,11 +30,21 @@ test('make sure value is not undefined if it is false', function() {
   var editor = new Editor({
     value: false
   });
-  
+
   same(editor.value, false);
 });
 
 test('sets to defaultValue if options.model and options.value are not set', function() {
+  var DefaultValueEditor = Editor.extend({
+    defaultValue: 'defaultValue'
+  });
+
+  var editor = new DefaultValueEditor();
+
+  same(editor.value, 'defaultValue');
+});
+
+test('base Editor defaultValue is null if nothing else is set', function() {
   var editor = new Editor();
 
   same(editor.value, null);
@@ -268,7 +278,7 @@ test('Given a string, a bundled validator is returned', function() {
 
   var required = editor.getValidator('required'),
       email = editor.getValidator('email');
-  
+
   equal(required(null).type, 'required');
   equal(email('invalid').type, 'email');
 });
@@ -288,14 +298,14 @@ test('Given an object, a customised bundled validator is returned', function() {
 
   //Can customise error message
   var required = editor.getValidator({ type: 'required', message: 'Custom message' });
-  
+
   var err = required('');
   equal(err.type, 'required');
   equal(err.message, 'Custom message');
-  
+
   //Can customise options on certain validators
   var regexp = editor.getValidator({ type: 'regexp', regexp: /foobar/, message: 'Must include "foobar"' });
-  
+
   var err = regexp('invalid');
   equal(err.type, 'regexp');
   equal(err.message, 'Must include "foobar"');
@@ -305,7 +315,7 @@ test('Given a regular expression, returns a regexp validator', function() {
   var editor = new Editor();
 
   var regexp = editor.getValidator(/hello/);
-  
+
   equal(regexp('invalid').type, 'regexp');
 });
 
@@ -319,7 +329,7 @@ test('Given a function, it is returned', function () {
   equal(validator, myValidator);
 });
 
-test('Given an unknown type, an error is thrown', 1, function () {    
+test('Given an unknown type, an error is thrown', 1, function () {
   var editor = new Editor();
 
   try {

--- a/test/editors/extra/list.js
+++ b/test/editors/extra/list.js
@@ -21,7 +21,7 @@ var same = deepEqual;
             slug: 'danger-zone',
             weapons: ['uzi', '9mm', 'sniper rifle']
         },
-        
+
         schema: {
             title:      { type: 'Text' },
             content:    { type: 'TextArea' },
@@ -119,7 +119,7 @@ var same = deepEqual;
         same(list.items.length, 1);
 
         list.$('[data-action="add"]').click();
-        
+
         same(list.items.length, 2);
     });
 
@@ -185,9 +185,47 @@ var same = deepEqual;
         same(actualOptions, expectedOptions);
     });
 
+    test('addItem() - with no value and a defaultValue on the itemType', function() {
+        var form = new Form();
+
+        editors.defaultValue = editors.Text.extend({
+            defaultValue: 'defaultValue'
+        });
+
+        var list = new List({
+            form: form,
+            schema: {
+                itemType: "defaultValue"
+            }
+        }).render();
+
+        var spy = this.sinon.spy(List, 'Item');
+
+        list.addItem();
+
+        var expectedOptions = {
+            form: form,
+            list: list,
+            schema: list.schema,
+            value: undefined,
+            Editor: editors.defaultValue,
+            key: list.key
+        };
+
+        var actualOptions = spy.lastCall.args[0];
+
+        same(spy.callCount, 1);
+        same(list.items.length, 2);
+        same(_.last(list.items).editor.value, 'defaultValue');
+        same(_.last(list.items).getValue(), 'defaultValue');
+
+        //Test options
+        same(actualOptions, expectedOptions);
+    });
+
     test('addItem() - with value', function() {
         var form = new Form();
-        
+
         var list = new List({
             form: form
         }).render();
@@ -242,7 +280,7 @@ var same = deepEqual;
 
     test('addItem() - sets editor focus if editor is not isAsync', function() {
         var list = new List().render();
-        
+
         this.sinon.spy(list.Editor.prototype, 'focus');
 
         list.addItem();
@@ -308,7 +346,7 @@ var same = deepEqual;
         //And item was removed
         same(list.items.length, 1, 'Removed item');
     });
-    
+
     test("focus() - gives focus to editor and its first item's editor", function() {
         var field = new List({
             model: new Post,
@@ -320,7 +358,7 @@ var same = deepEqual;
 
         ok(field.items[0].editor.hasFocus);
         ok(field.hasFocus);
-        
+
         field.remove();
     });
 
@@ -403,7 +441,7 @@ var same = deepEqual;
         ok(spy.called);
         ok(spy.calledWith(field));
     });
-    
+
     test("'change' event - is triggered when an item is added", function() {
         var field = new List({
             model: new Post,
@@ -411,7 +449,7 @@ var same = deepEqual;
         }).render();
 
         var spy = this.sinon.spy();
-        
+
         field.on('change', spy);
 
         var item = field.addItem(null, true);
@@ -419,7 +457,7 @@ var same = deepEqual;
         ok(spy.called);
         ok(spy.calledWith(field));
     });
-    
+
     test("'change' event - is triggered when an item is removed", function() {
         var field = new List({
             model: new Post,
@@ -427,7 +465,7 @@ var same = deepEqual;
         }).render();
 
         var spy = this.sinon.spy();
-        
+
         var item = field.items[0];
 
         field.on('change', spy);
@@ -542,7 +580,7 @@ var same = deepEqual;
             start();
         }, 0);
     });
-    
+
     test("'add' event - is triggered when an item is added", function() {
         var field = new List({
             model: new Post,
@@ -550,7 +588,7 @@ var same = deepEqual;
         }).render();
 
         var spy = this.sinon.spy();
-        
+
         field.on('add', spy);
 
         var item = field.addItem(null, true);
@@ -558,7 +596,7 @@ var same = deepEqual;
         ok(spy.called);
         ok(spy.calledWith(field, item.editor));
     });
-    
+
     test("'remove' event - is triggered when an item is removed", function() {
         var field = new List({
             model: new Post,
@@ -617,7 +655,7 @@ module('List.Item', {
       var CustomItem = List.Item.extend({}, {
         template: constructorTemplate
       });
-      
+
       //Options
       var item = new CustomItem({
         template: optionsTemplate,
@@ -793,7 +831,7 @@ module('List.Modal', {
         this.editor = new editors.List.Modal({
             form: new Form()
         });
-        
+
         //Force nestedSchema because this is usually done by Object or NestedModel constructors
         this.editor.nestedSchema = {
             id: { type: 'Number' },

--- a/test/form.js
+++ b/test/form.js
@@ -336,6 +336,68 @@ test('submitButton option: string - creates button with given text', function() 
 });
 
 
+module('Form#EditorValues');
+
+test('Form with editor with basic schema should return defaultValues', function() {
+  var form = new Form({
+    schema: {
+      name: {
+        type: 'Text'
+      }
+    }
+  }).render();
+
+  same( form.fields.name.editor.value, "" );
+  same( form.getValue(), { name: "" } );
+});
+
+test('Form with model with defaults should return defaults', function() {
+  var model = Backbone.Model.extend({
+    defaults: { name: "Default Name" }
+  });
+  var form = new Form({
+    schema: {
+      name: {
+        type: 'Text'
+      }
+    },
+    model: new model()
+  }).render();
+
+  same( form.fields.name.editor.value, "Default Name" );
+  same( form.getValue(), { name: "Default Name" } );
+});
+
+test('Form with data passed in should return data', function() {
+  var form = new Form({
+    schema: {
+      name: {
+        type: 'Text'
+      }
+    },
+    data: { name: "Default Name" }
+  }).render();
+
+  same( form.fields.name.editor.value, "Default Name" );
+  same( form.getValue(), { name: "Default Name" } );
+});
+
+test('Form should not clobber defaultValue of Editors', function() {
+  Form.editors.DefaultText = Form.editors.Text.extend({
+    defaultValue: "Default Name"
+  });
+  var form = new Form({
+    schema: {
+      name: {
+        type: 'DefaultText'
+      }
+    }
+  }).render();
+
+  same( form.fields.name.editor.value, "Default Name" );
+  same( form.getValue(), { name: "Default Name" } );
+});
+
 
 module('Form#createFieldset', {
   setup: function() {
@@ -689,17 +751,17 @@ test('returns model validation errors by default', function() {
 
 test('skips model validation if { skipModelValidate: true } is passed', function() {
   var model = new Backbone.Model();
-  
+
   model.validate = function() {
     return 'ERROR';
   };
-  
+
   var form = new Form({
     model: model
   });
-  
+
   var err = form.validate({ skipModelValidate: true });
-  
+
   same(err, null);
 });
 
@@ -734,23 +796,23 @@ test('does not return  model validation errors by default', function() {
   });
 
   var err = form.commit();
-  
+
   same(err, undefined);
 });
 
 test('returns model validation errors when { validate: true } is passed', function() {
   var model = new Backbone.Model();
-  
+
   model.validate = function() {
     return 'ERROR';
   };
-  
+
   var form = new Form({
     model: model
   });
-  
+
   var err = form.commit({ validate: true });
-  
+
   same(err._others, ['ERROR']);
 });
 


### PR DESCRIPTION
Referencing - https://github.com/powmedia/backbone-forms/issues/395

The tests didn't show this problem with the list editor, because of calling addItem directly and passing no value, whereas (as Tim points out), clicking the add button adds it with 'null', which over-rides the default value.

There doesn't appear to be a test for the click to add process, and I'm hesitant to add one because I haven't used sinon before, and am not sure what special requirements it might need for simulating events.

There is also a very similar problem with normal editors, when created by a Form.
https://github.com/powmedia/backbone-forms/blob/master/src/form.js#L114-L120

##### Functional Changes
- made List add button click pass undefined instead of null
- made Form 'createField' method set options value to undefined instead of null

##### Test Changes
- added Form tests to create schemas with a defaultValue and make sure it wasn't being clobbered
- added an Editor test to look for defaultValue other than null
    - this one doesn't strictly do anything, since the problem was only for an editor created via a Form, but checking only for defaultValues of null might not actually be very revealing.
- added a List test for an editor itemType with a defaultValue

If you rollback the functional changes, you can see the new tests failing.

Is it bad etiquette to have a PR spammed with whitespace diffs? I'm not sure how to get rid of it!