### PR TITLE
Add disable/enable methods to field

### DIFF
--- a/src/field.js
+++ b/src/field.js
@@ -7,7 +7,7 @@ Form.Field = Backbone.View.extend({
 
   /**
    * Constructor
-   * 
+   *
    * @param {Object} options.key
    * @param {Object} options.form
    * @param {Object} [options.schema]
@@ -166,6 +166,38 @@ Form.Field = Backbone.View.extend({
     this.setElement($field);
 
     return this;
+  },
+
+  /**
+   * Disable the field's editor
+   * Will call the editor's disable method if it exists
+   * Otherwise will add the disabled attribute to all inputs in the editor
+   */
+  disable: function(){
+    if ( _.isFunction(this.editor.disable) ){
+      this.editor.disable();
+    }
+    else {
+      $input = this.editor.$el;
+      $input = $input.is("input") ? $input : $input.find("input");
+      $input.attr("disabled",true);
+    }
+  },
+
+  /**
+   * Enable the field's editor
+   * Will call the editor's disable method if it exists
+   * Otherwise will remove the disabled attribute to all inputs in the editor
+   */
+  enable: function(){
+    if ( _.isFunction(this.editor.enable) ){
+      this.editor.enable();
+    }
+    else {
+      $input = this.editor.$el;
+      $input = $input.is("input") ? $input : $input.find("input");
+      $input.attr("disabled",false);
+    }
   },
 
   /**

--- a/test/field.js
+++ b/test/field.js
@@ -180,7 +180,7 @@ module('Field#createEditor', {
   }
 });
 
-test('creates a new instance of the Editor defined in the schema', function() {  
+test('creates a new instance of the Editor defined in the schema', function() {
   var field = new Field({
     key: 'password',
     schema: { type: 'Password' },
@@ -216,12 +216,12 @@ test('uses idPrefix if defined', function() {
     idPrefix: 'foo_',
     key: 'name'
   });
-  
+
   var numberPrefixField = new Field({
     idPrefix: 123,
     key: 'name'
   });
-  
+
   same(numberPrefixField.createEditorId(), '123name');
 });
 
@@ -230,7 +230,7 @@ test('adds no prefix if idPrefix is null', function() {
     idPrefix: null,
     key: 'name'
   });
-  
+
   same(field.createEditorId(), 'name');
 });
 
@@ -242,7 +242,7 @@ test('uses model cid if no idPrefix is set', function() {
     key: 'name',
     model: model
   });
-  
+
   same(field.createEditorId(), 'foo_name');
 });
 
@@ -250,7 +250,7 @@ test('adds no prefix if idPrefix is null and there is no model', function() {
   var field = new Field({
     key: 'name'
   });
-  
+
   same(field.createEditorId(), 'name');
 });
 
@@ -357,11 +357,11 @@ test('calls setError if validation fails', 4, function() {
   });
 
   this.sinon.spy(field, 'setError');
-  
+
   //Make validation fail
   field.setValue(null);
   var err = field.validate();
-  
+
   //Test
   same(field.setError.callCount, 1);
   same(field.setError.args[0][0], 'Required');
@@ -377,15 +377,15 @@ test('calls clearError if validation passes', 1, function() {
   });
 
   this.sinon.spy(field, 'clearError');
-  
+
   //Trigger error to appear
   field.setValue(null);
   field.validate();
-    
+
   //Trigger validation to pass
   field.setValue('ok');
   field.validate();
-  
+
   //Test
   same(field.clearError.callCount, 1);
 });
@@ -481,7 +481,7 @@ test('Calls editor commit', function() {
   this.sinon.spy(field.editor, 'commit');
 
   field.commit();
-  
+
   same(field.editor.commit.callCount, 1);
 });
 
@@ -496,7 +496,7 @@ test('Returns error from validation', function() {
   });
 
   var result = field.commit();
-  
+
   same(result, { type: 'required' });
 });
 
@@ -521,7 +521,7 @@ test('Returns the value from the editor', function() {
     this.sinon.spy(field.editor, 'getValue');
 
     var result = field.getValue();
-    
+
     same(field.editor.getValue.callCount, 1);
     same(result, 'The Title');
 });
@@ -542,9 +542,9 @@ test('Passes the new value to the editor', function() {
     var field = new Field({ key: 'title' });
 
     this.sinon.spy(field.editor, 'setValue');
-    
+
     field.setValue('New Title');
-    
+
     same(field.editor.setValue.callCount, 1);
     same(field.editor.setValue.args[0][0], 'New Title');
 });
@@ -565,9 +565,9 @@ test('Calls focus on editor', function() {
   var field = new Field({ key: 'title' });
 
   this.sinon.spy(field.editor, 'focus');
-  
+
   field.focus();
-  
+
   same(field.editor.focus.callCount, 1);
 });
 
@@ -587,11 +587,90 @@ test('Calls focus on editor', function() {
   var field = new Field({ key: 'title' });
 
   this.sinon.spy(field.editor, 'blur');
-  
+
   field.blur();
-  
+
   same(field.editor.blur.callCount, 1);
 });
+
+
+
+module('Field#disable', {
+  setup: function() {
+    this.sinon = sinon.sandbox.create();
+  },
+
+  teardown: function() {
+    this.sinon.restore();
+  }
+});
+
+test('Calls disable on editor if method exists', function() {
+  Form.editors.Disabler = Form.editors.Text.extend({
+    disable: function(){}
+  });
+  var field = new Field({
+    schema: { type: "Disabler" },
+    key: 'title'
+  });
+
+  this.sinon.spy(field.editor, 'disable');
+
+  field.disable();
+
+  same(field.editor.disable.callCount, 1);
+});
+
+test('If disable method does not exist on editor, disable all inputs inside it', function() {
+  var field = new Field({ key: 'title' });
+
+  field.render();
+
+  field.disable();
+
+  same(field.$("input").is(":disabled"),true);
+});
+
+
+
+module('Field#enable', {
+  setup: function() {
+    this.sinon = sinon.sandbox.create();
+  },
+
+  teardown: function() {
+    this.sinon.restore();
+  }
+});
+
+test('Calls enable on editor if method exists', function() {
+  Form.editors.Enabler = Form.editors.Text.extend({
+    enable: function(){}
+  });
+  var field = new Field({
+    schema: { type: "Enabler" },
+    key: 'title'
+  });
+
+  this.sinon.spy(field.editor, 'enable');
+
+  field.enable();
+
+  same(field.editor.enable.callCount, 1);
+});
+
+test('If enable method does not exist on editor, enable all inputs inside it', function() {
+  var field = new Field({ key: 'title' });
+
+  field.$("input").attr("disabled",true);
+
+  field.render();
+
+  field.enable();
+
+  same(field.$("input").is(":disabled"),false);
+});
+
 
 
 


### PR DESCRIPTION
This adds enable and disable methods to the Field class. The goal is to stream-line disabling editors, instead of having to use your editor's CSS selector on the page.

These methods will attempt to call any enable/disable on the editor (like focus/blur). These methods are NOT required, but are useful for custom editors that might have more complicated disable/enable scenarios. (fe - an Autocomplete that should close its options when disabled).

If the editor doesn't have the method, the field's disable/enable methods will disable all inputs in the editor.$el, or the editor.$el itself, if it is an input as with Text Editor. ( This 'default' logic branch might make more sense as default disable/enable methods on the Base editor class )

This is useful for Checkboxes, Radios, and the default List Text editor.

However, the 'all inputs' approach might be too naive. For example, these methods currently do nothing to TextArea or Select editors.
