### PR TITLE
fixes #414

### DIFF
--- a/src/editors/object.js
+++ b/src/editors/object.js
@@ -76,7 +76,11 @@ Form.editors.Object = Form.editors.Base.extend({
   },
 
   validate: function() {
-    return this.nestedForm.validate();
+    var errors = _.extend({}, 
+      Form.editors.Base.prototype.validate.call(this),
+      this.nestedForm.validate()
+    );
+    return errors; 
   },
 
   _observeFormEvents: function() {

--- a/test/editors/object.js
+++ b/test/editors/object.js
@@ -93,7 +93,9 @@
   });
 
   test('validate() - returns validation errors', function() {
-    var schema = {};
+    var schema = {
+      validators: [function a(a,b) { return {modelCheck:true}}]
+    };
     schema.subSchema = {
       id:     { validators: ['required'] },
       name:   {},
@@ -113,6 +115,7 @@
 
     equal(errs.id.type, 'required');
     equal(errs.email.type, 'email');
+    equal(errs.modelCheck, true);
   });
 
 


### PR DESCRIPTION
Allow Nested Model Validation

Useage for example having a general model which you want some custom validation on.

Eg a Person object which names to have just letters, but the specific use of the person can only have a name < 12 chars long.
