### PR TITLE
Add an ability to pass function into schema options

### DIFF
--- a/src/field.js
+++ b/src/field.js
@@ -123,11 +123,11 @@ Form.Field = Backbone.View.extend({
     var schema = this.schema;
 
     return {
-      help: schema.help || '',
-      title: schema.title,
-      titleHTML: schema.titleHTML,
-      fieldAttrs: schema.fieldAttrs,
-      editorAttrs: schema.editorAttrs,
+      help: _.result(schema, 'help') || '',
+      title: _.result(schema, 'title'),
+      titleHTML: _.result(schema, 'titleHTML'),
+      fieldAttrs: _.result(schema, 'fieldAttrs'),
+      editorAttrs: _.result(schema, 'editorAttrs'),
       key: this.key,
       editorId: this.editor.id
     };


### PR DESCRIPTION
You couldn't pass function into schema options before, because underscore
templates were just using toString on those function, without calling
them. (e.g. `function () { return App.t("entities.contract.num"); }`, instead of the result of that function)

I decided to use _.result to call those function if necessary and now you can make schema options dynamic.

I stumbled upon this issue, because I'm using polyglot.js to implement i18n and its helpers isn't available until later, when Backbone.form initialization code was already loaded.

Here's an example how it worked before the changes to make it clearer:

``` javascript
var User = Backbone.Model.extend({
    schema: {
        title:      {
           // this would return function () { return App.t("entities.contract.num"); }
            title: function(){ return App.t("entities.user.title"); }

           // this wouldn't work, because App.t isn't available at that moment
            title: App.t("entities.user.title")
        },
    }
});
```
