### PR TITLE
Support for "maxCardinality" in the list editor.

### DIFF
--- a/src/editors/extra/list.js
+++ b/src/editors/extra/list.js
@@ -70,6 +70,10 @@
         if (!this.Editor.isAsync) this.addItem();
       }
 
+      // hide the "add" button in case the cardinality has been reached
+      if (self.schema.maxCardinality && self.items.length >= self.schema.maxCardinality)
+        $el.find('button[data-action="add"]').hide();
+
       this.setElement($el);
       this.$el.attr('id', this.id);
       this.$el.attr('name', this.key);
@@ -102,6 +106,11 @@
         self.items.push(item);
         self.$list.append(item.el);
         
+        // hide the "add" button in case the cardinality has been reached
+        if (self.schema.maxCardinality && self.items.length >= self.schema.maxCardinality) {
+          self.$el.find('button[data-action="add"]').hide();
+        }
+
         item.editor.on('all', function(event) {
           if (event === 'change') return;
 
@@ -180,6 +189,10 @@
       }
 
       if (!this.items.length && !this.Editor.isAsync) this.addItem();
+
+      // show the "add" button in case the cardinality has not been reached
+      if (this.schema.maxCardinality && this.items.length < this.schema.maxCardinality)
+        this.$el.find('button[data-action="add"]').show();
     },
 
     getValue: function() {


### PR DESCRIPTION
This allows add "maxCardinality" to the schema which will hide or
show the "add" button based on the number of values in the list.

It is a very simple but effective addition - maybe you will find it worth pulling. :)