### PR TITLE
update fieldset.js: render based on schema.fields

### DIFF
--- a/src/fieldset.js
+++ b/src/fieldset.js
@@ -89,8 +89,8 @@ Form.Fieldset = Backbone.View.extend({
 
       if (_.isUndefined(selection)) return;
 
-      _.each(fields, function(field) {
-        $container.append(field.render().el);
+      _.each(schema.fields, function(fieldName) {
+      $container.append(fields[fieldName].render().el);
       });
     });
 


### PR DESCRIPTION
Currently `Fieldset.render` renders based on `fieldset.fields` (which is an object) instead of `fieldset.schema.fields` (which is an array).

Besides the suggested pull being more robust in the default case, it allows me to have some extended methods to change form/fielset/field schemas (field ordening among one) and have form.render correctly reflect the updated schemas.