### PR TITLE
Enable the use of editor objects in lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,6 +613,11 @@ This is a special editor which is in **a separate file and must be included**:
 
   Optional, but recommended when using itemType 'Object'. When itemType is 'NestedModel', the model's `toString()` method will be used, unless a specific `itemToString()` function is defined on the schema.
 
+- **`itemClass`**
+
+  A class to use instead of `List.Item`
+
+  The default class wraps each editor in a `<div>` and adds a "delete" button on each row. Provide this argument and `List` will use your custom item class, allowing you to customize this behavior.
 
 ###Events
 

--- a/src/editors/extra/list.js
+++ b/src/editors/extra/list.js
@@ -41,7 +41,7 @@
         if (editors.List[type]) return editors.List[type];
 
         //Or whichever was passed
-        return editors[type];
+        return (_.isString(type)) ? editors[type] : type;
       })();
 
       this.items = [];

--- a/src/editors/extra/list.js
+++ b/src/editors/extra/list.js
@@ -44,6 +44,8 @@
         return (_.isString(type)) ? editors[type] : type;
       })();
 
+      this.ListItem = schema.itemClass || editors.List.Item;
+
       this.items = [];
     },
 
@@ -89,7 +91,7 @@
           editors = Form.editors;
 
       //Create the item
-      var item = new editors.List.Item({
+      var item = new this.ListItem({
         list: this,
         form: this.form,
         schema: this.schema,


### PR DESCRIPTION
This PR just copies the editor-finding logic from `fields.js` to `list.js`, allowing me to use an editor that isn't in the `Form.editors` object.