### PR TITLE
Fix bootstrap 3 checkboxes by removing form-control class.

### DIFF
--- a/distribution.amd/templates/bootstrap3.js
+++ b/distribution.amd/templates/bootstrap3.js
@@ -55,6 +55,8 @@ define(['jquery', 'underscore', 'backbone', 'backbone-forms'], function($, _, Ba
   ');
 
   Form.editors.Base.prototype.className = 'form-control';
+  Form.editors.Checkbox.prototype.className = 'checkbox';
+  Form.editors.Checkboxes.prototype.className = 'checkbox';
   Form.Field.errorClassName = 'has-error';
 
 

--- a/distribution/templates/bootstrap3.js
+++ b/distribution/templates/bootstrap3.js
@@ -54,6 +54,8 @@
   ');
 
   Form.editors.Base.prototype.className = 'form-control';
+  Form.editors.Checkbox.prototype.className = 'checkbox';
+  Form.editors.Checkboxes.prototype.className = 'checkbox';
   Form.Field.errorClassName = 'has-error';
 
 

--- a/examples/register-form-custom-template/index.html
+++ b/examples/register-form-custom-template/index.html
@@ -26,7 +26,7 @@
     <div data-fields="title,name,birthday"></div>
 
     <h2>Login details</h2>
-    <div data-fields="email,password,confirmPassword"></div>
+    <div data-fields="email,password,confirmPassword,active"></div>
 
     <input type="submit" class="btn btn-primary submit" />
   </form>

--- a/examples/register-form-custom-template/main.js
+++ b/examples/register-form-custom-template/main.js
@@ -27,6 +27,9 @@ $(function() {
           'required',
           { type: 'match', field: 'password', message: 'Passwords must match!' }
         ]
+      },
+      active: {
+        type: 'Checkbox'
       }
     }
     

--- a/scripts/build
+++ b/scripts/build
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 var builder = require('buildify'),
-    path = require('path');
+    fs = require('fs');
 
 var templateData = {
   version: require('../package.json').version
@@ -66,7 +66,7 @@ builder(baseDir)
     .save('distribution/editors/'+name+'.min.js');
 
   //CSS file
-  if (path.existsSync(baseDir + '/src/editors/'+name+'.css')) {
+  if (fs.existsSync(baseDir + '/src/editors/'+name+'.css')) {
     builder(baseDir)
       .load('src/editors/extra/'+name+'.css')
       .save('distribution/editors/'+name+'.css')

--- a/src/templates/bootstrap3.js
+++ b/src/templates/bootstrap3.js
@@ -47,6 +47,8 @@
   ');
 
   Form.editors.Base.prototype.className = 'form-control';
+  Form.editors.Checkbox.prototype.className = 'checkbox';
+  Form.editors.Checkboxes.prototype.className = 'checkbox';
   Form.Field.errorClassName = 'has-error';
 
 


### PR DESCRIPTION
This fixes issue #385. With bootstrap 3, checkboxes cannot have a "form-control" class, otherwise it will overlay an input box beneath the actual checkboxes.