### PR TITLE
IE8 fix - label tag needs to be closed.

### DIFF
--- a/src/editors/checkboxes.js
+++ b/src/editors/checkboxes.js
@@ -81,16 +81,16 @@ Form.editors.Checkboxes = Form.editors.Select.extend({
           var val = (option.val || option.val === 0) ? option.val : '';
           itemHtml.append( $('<input type="checkbox" name="'+self.getName()+'" id="'+self.id+'-'+index+'" />').val(val) );
           if (option.labelHTML){
-            itemHtml.append( $('<label for="'+self.id+'-'+index+'">').html(option.labelHTML) );
+            itemHtml.append( $('<label for="'+self.id+'-'+index+'" />').html(option.labelHTML) );
           }
           else {
-            itemHtml.append( $('<label for="'+self.id+'-'+index+'">').text(option.label) );
+            itemHtml.append( $('<label for="'+self.id+'-'+index+'" />').text(option.label) );
           }
         }
       }
       else {
         itemHtml.append( $('<input type="checkbox" name="'+self.getName()+'" id="'+self.id+'-'+index+'" />').val(option) );
-        itemHtml.append( $('<label for="'+self.id+'-'+index+'">').text(option) );
+        itemHtml.append( $('<label for="'+self.id+'-'+index+'" />').text(option) );
       }
       html = html.add(itemHtml);
     });


### PR DESCRIPTION
IE8 throws a "Object doesn't support this property or method" error when this label is created (because the tag is unclosed).

Ensuring the tag is correctly closed fixes the issue.

All the tests are pretty busted in IE8, so didn't really add a test for this (I figured it was a lost cause...)

And I also understand if you don't support IE8 and hence don't want to accept the PR :-)