### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ $('body').append(form.el);
 
 
 ###Live editable demos
-- [User form](http://jsfiddle.net/evilcelery/dW2Qu/)
-- [Update form elements based on user input](http://jsfiddle.net/evilcelery/c5QHr/)
-- [Validate on blur](http://jsfiddle.net/evilcelery/FqLR2/)
+- [User form](http://jsfiddle.net/gfaq5km1/)
+- [Update form elements based on user input](http://jsfiddle.net/wc7e97v1/)
+- [Validate on blur](http://jsfiddle.net/68s6ynfh/)
 
 
 


### PR DESCRIPTION
Update jsfiddle examples with CDN instead of documentCloud, which is no longer valid.