### PR TITLE
update email regex to meet RFC 5322 requirements

### DIFF
--- a/distribution/backbone-forms.js
+++ b/distribution/backbone-forms.js
@@ -574,7 +574,7 @@ Form.validators = (function() {
     options = _.extend({
       type: 'email',
       message: this.errMessages.email,
-      regexp: /^[\w\-]{1,}([\w\-\+.]{1,1}[\w\-]{1,}){0,}[@][\w\-]{1,}([.]([\w\-]{1,})){1,3}$/
+      regexp: /^[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i
     }, options);
     
     return validators.regexp(options);


### PR DESCRIPTION
regex borrowed from http://www.regular-expressions.info/email.html, previous regex wouldn't allow valid (and somewhat common) emails like brian.o'connel@mail.com.