### PR TITLE
Fix failing tests.

### DIFF
--- a/test/editors/extra/list.js
+++ b/test/editors/extra/list.js
@@ -162,7 +162,7 @@ var same = deepEqual;
             form: form
         }).render();
 
-        var spy = this.sinon.spy(List, 'Item');
+        var spy = this.sinon.spy(editors.List.Item.prototype, 'initialize');
 
         list.addItem();
 
@@ -230,7 +230,7 @@ var same = deepEqual;
             form: form
         }).render();
 
-        var spy = this.sinon.spy(List, 'Item');
+        var spy = this.sinon.spy(editors.List.Item.prototype, 'initialize');
 
         list.addItem('foo');
 
@@ -1315,6 +1315,9 @@ test('initialize() - sets the nestedSchema, when schema is function', function()
 
 test('Check validation of list nested models', function() {
 
+    //Save proto for restoring after the test otherwise next fails alternately.
+    var tmpNestedModel = Backbone.Form.editors.List.NestedModel;
+
      Backbone.Form.editors.List.NestedModel = Backbone.Form.editors.NestedModel;
      var NestedModel = Backbone.Model.extend({
        schema: {
@@ -1328,6 +1331,8 @@ test('Check validation of list nested models', function() {
        schema: schema,
      }).render();
 
+     Backbone.Form.editors.List.NestedModel = tmpNestedModel;
+
      deepEqual(_.keys(form.validate().nestedModelList.errors[0]), ['name']);
 });
 
@@ -1337,6 +1342,8 @@ test('getStringValue() - uses model.toString() if available', function() {
     }
 
     this.editor.setValue({ id: 1, name: 'foo' });
+
+    console.log('editor ', this.editor);
 
     equal(this.editor.getStringValue(), 'foo!');
 });

--- a/test/editors/extra/list.js
+++ b/test/editors/extra/list.js
@@ -1343,8 +1343,6 @@ test('getStringValue() - uses model.toString() if available', function() {
 
     this.editor.setValue({ id: 1, name: 'foo' });
 
-    console.log('editor ', this.editor);
-
     equal(this.editor.getStringValue(), 'foo!');
 });
 

--- a/test/validators.js
+++ b/test/validators.js
@@ -232,8 +232,6 @@
   test('fails invalid emails', function() {
     ok(fn('invalid'))
     ok(fn('email@example'))
-    ok(fn('foo/bar@example.com'))
-    ok(fn('foo?bar@example.com'))
     ok(fn('foo@exa#mple.com'))
     ok(fn(234))
     ok(fn('#@%^%#$@#$@#.com'))
@@ -253,6 +251,8 @@
   })
 
   test('accepts valid emails', function() {
+    equal(fn('foo/bar@example.com'), undefined)
+    equal(fn('foo?bar@example.com'), undefined)
     equal(fn('test@example.com'), undefined)
     equal(fn('john.smith@example.com'), undefined)
     equal(fn('john.smith@example.co.uk'), undefined)


### PR DESCRIPTION
Move 2 email regex tests from invalid to valid #489
Fix problems with adding list items - spy on 'initialize' instead
of Class constructor, possibly fallout from #451
List.NestedModel getStringValue test was failing on alternate runs,
the previous test messed with the prototype, which seemed to
cause the fail - restore the proto after test.