### PR TITLE
Stop add event on child list from propagating to parent list

### DIFF
--- a/distribution/editors/list.js
+++ b/distribution/editors/list.js
@@ -14,6 +14,7 @@
     events: {
       'click [data-action="add"]': function(event) {
         event.preventDefault();
+        event.stopPropagation();
         this.addItem(null, true);
       }
     },


### PR DESCRIPTION
See https://github.com/powmedia/backbone-forms/issues/502