### PR TITLE
Set select value if value is not null or undefined

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.iml
 *.ipr
 *.iws
+.idea

--- a/src/editors/select.js
+++ b/src/editors/select.js
@@ -151,7 +151,9 @@ Form.editors.Select = Form.editors.Base.extend({
 
   setValue: function(value) {
     this.value = value;
-    this.$el.val(value);
+    if (value != undefined) {
+      this.$el.val(value);
+    }
   },
 
   focus: function() {


### PR DESCRIPTION
The jquery versions that are less than 1.10 doesn't allow to set
non-existing select value. However, 1.10 and above versions allows to
set null value or any non-existing value. I found it is confusing. This happens
when Backbone model doesn't have default value.

I came to this problem after I upgrade jquery from 1.8 to 1.11
