### PR TITLE
Allow the list editor to handle a collection as well as an array.

### DIFF
--- a/src/editors/extra/list.js
+++ b/src/editors/extra/list.js
@@ -66,9 +66,12 @@
       //Store a reference to the list (item container)
       this.$list = $el.is('[data-items]') ? $el : $el.find('[data-items]');
 
+      if (value instanceof Backbone.Collection) {
+        value = value.toJSON();
+      }
       //Add existing items
       if (value.length) {
-        _.each(value, function(itemValue) {
+        _.each(value, function addItem(itemValue) {
           self.addItem(itemValue);
         });
       }

--- a/test/editors/extra/list.js
+++ b/test/editors/extra/list.js
@@ -88,7 +88,7 @@ var same = deepEqual;
         var list = new List({
             schema: { addLabel: 'Agregar' }
         }).render();
-        
+
         same(list.$('[data-action="add"]').text(), 'Agregar');
     });
 
@@ -153,16 +153,40 @@ var same = deepEqual;
         ok(list.$list.hasClass('customList'));
     });
 
-    test('render() - creates items for each item in value array', function() {
-        var list = new List({
-            value: [1,2,3]
-        });
-
+    function testItemCreate(list, values) {
         same(list.items.length, 0);
 
         list.render();
 
         same(list.items.length, 3);
+
+        same(values, _.pluck(list.items, 'value'));
+    }
+
+    test('render() - creates items for each item in value array', function() {
+        var values = [1,2,3];
+
+        var list = new List({
+            schema: { itemType: 'Number' },
+            value: values
+        });
+
+        testItemCreate(list, values);
+    });
+
+    test('render() - creates items for each item in value collection', function() {
+        var values = [
+            { value: 1 },
+            { value: 2 },
+            { value: 3 }
+        ];
+        var list = new List({
+            schema: { itemType: 'Number' },
+            key: 'value',
+            value: new Backbone.Collection(values)
+        });
+
+        testItemCreate(list, values);
     });
 
     test('render() - creates an initial empty item for empty array', function() {


### PR DESCRIPTION
Fixes #520
If the value has been passed as a collection, then convert this to
an array before trying to add items.
Add test for this, make array test more robust and de-dupe.