### PR TITLE
Bug #525 - optimise rendering of select options.

### DIFF
--- a/src/editors/select.js
+++ b/src/editors/select.js
@@ -212,7 +212,7 @@ Form.editors.Select = Form.editors.Base.extend({
    * @return {String} HTML
    */
   _arrayToHtml: function(array) {
-    var html = $();
+    var html = [];
 
     //Generate HTML
     _.each(array, function(option) {
@@ -221,18 +221,18 @@ Form.editors.Select = Form.editors.Base.extend({
           var optgroup = $("<optgroup>")
             .attr("label",option.group)
             .html( this._getOptionsHtml(option.options) );
-          html = html.add(optgroup);
+          html[html.length] = optgroup[0];
         } else {
           var val = (option.val || option.val === 0) ? option.val : '';
-          html = html.add( $('<option>').val(val).text(option.label) );
+          html[html.length] = $('<option>').val(val).text(option.label)[0];
         }
       }
       else {
-        html = html.add( $('<option>').text(option) );
+        html[html.length] = $('<option>').text(option)[0];
       }
     }, this);
 
-    return html;
+    return $().add(html);
   }
 
 });

--- a/test/editors/select.js
+++ b/test/editors/select.js
@@ -410,6 +410,29 @@
     equal(newOptions.last().html(), 'Phil');
   });
 
+
+  test('Rendering: Only adds options to the DOM with one function call ', function() {
+    var options = [],
+        length = 4000;
+
+    for(var i = 0;i < length;i++) {
+      options.push('option-' + i);
+    }
+
+    var editor = new Editor({
+      schema: {
+        options: options
+      }
+    });
+
+    var spy = sinon.spy($.fn, 'add');
+
+    editor.render();
+
+    equal(spy.callCount, 1);
+
+  });
+
   test("setValue() - updates the input value", function() {
     var editor = new Editor({
       value: 'Pam',


### PR DESCRIPTION
As per fix, push each rendered element into an array which we
then pass to $.fn.add in one go - more efficient.
Add test to ensure that add only gets called once.