### PR TITLE
lodash 4.x compatibility fixes #515

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,21 +1,13 @@
 {
-  
   "name": "backbone-forms",
-
   "main": [
-    
     "distribution/backbone-forms.js"
-    
   ],
-  
   "dependencies": {
-    
     "backbone": ">=1.0.0"
-    
   },
-  
   "devDependencies": {
-    
+    "lodash": "~4.16.4",
+    "backbone-deep-model": "~0.10.4"
   }
-  
 }

--- a/src/editors/checkboxes.js
+++ b/src/editors/checkboxes.js
@@ -23,19 +23,19 @@ Form.editors.Checkboxes = Form.editors.Select.extend({
     },
     'blur input[type=checkbox]':  function() {
       if (!this.hasFocus) return;
-      var self = this;
-      setTimeout(function() {
+
+      _.defer(function(self) {
         if (self.$('input[type=checkbox]:focus')[0]) return;
         self.trigger('blur', self);
-      }, 0);
+      }, this);
     }
   },
 
   getValue: function() {
     var values = [];
-    var self = this;
+
     this.$('input[type=checkbox]:checked').each(function() {
-      values.push(self.$(this).val());
+      values.push(this.value);
     });
     return values;
   },
@@ -66,35 +66,34 @@ Form.editors.Checkboxes = Form.editors.Select.extend({
    */
   _arrayToHtml: function (array) {
     var html = $();
-    var self = this;
 
-    _.each(array, function(option, index) {
+    _.each(array, _.bind(function(option, index) {
       var itemHtml = $('<li>');
       if (_.isObject(option)) {
         if (option.group) {
-          var originalId = self.id;
-          self.id += "-" + self.groupNumber++;
+          var originalId = this.id;
+          this.id += "-" + this.groupNumber++;
           itemHtml = $('<fieldset class="group">').append( $('<legend>').text(option.group) );
-          itemHtml = itemHtml.append( self._arrayToHtml(option.options) );
-          self.id = originalId;
+          itemHtml = itemHtml.append( this._arrayToHtml(option.options) );
+          this.id = originalId;
           close = false;
         }else{
           var val = (option.val || option.val === 0) ? option.val : '';
-          itemHtml.append( $('<input type="checkbox" name="'+self.getName()+'" id="'+self.id+'-'+index+'" />').val(val) );
+          itemHtml.append( $('<input type="checkbox" name="'+this.getName()+'" id="'+this.id+'-'+index+'" />').val(val) );
           if (option.labelHTML){
-            itemHtml.append( $('<label for="'+self.id+'-'+index+'" />').html(option.labelHTML) );
+            itemHtml.append( $('<label for="'+this.id+'-'+index+'" />').html(option.labelHTML) );
           }
           else {
-            itemHtml.append( $('<label for="'+self.id+'-'+index+'" />').text(option.label) );
+            itemHtml.append( $('<label for="'+this.id+'-'+index+'" />').text(option.label) );
           }
         }
       }
       else {
-        itemHtml.append( $('<input type="checkbox" name="'+self.getName()+'" id="'+self.id+'-'+index+'" />').val(option) );
-        itemHtml.append( $('<label for="'+self.id+'-'+index+'" />').text(option) );
+        itemHtml.append( $('<input type="checkbox" name="'+this.getName()+'" id="'+this.id+'-'+index+'" />').val(option) );
+        itemHtml.append( $('<label for="'+this.id+'-'+index+'" />').text(option) );
       }
       html = html.add(itemHtml);
-    });
+    }, this));
 
     return html;
   }

--- a/src/editors/select.js
+++ b/src/editors/select.js
@@ -215,7 +215,7 @@ Form.editors.Select = Form.editors.Base.extend({
     var html = $();
 
     //Generate HTML
-    _.each(array, function(option) {
+    _.each(array, _.bind(function(option) {
       if (_.isObject(option)) {
         if (option.group) {
           var optgroup = $("<optgroup>")
@@ -230,7 +230,7 @@ Form.editors.Select = Form.editors.Base.extend({
       else {
         html = html.add( $('<option>').text(option) );
       }
-    }, this);
+    }, this));
 
     return html;
   }

--- a/src/form.js
+++ b/src/form.js
@@ -64,18 +64,18 @@ var Form = Backbone.View.extend({
     //Create fields
     var fields = this.fields = {};
 
-    _.each(selectedFields, function(key) {
+    _.each(selectedFields, _.bind(function(key) {
       var fieldSchema = schema[key];
       fields[key] = this.createField(key, fieldSchema);
-    }, this);
+    }, this));
 
     //Create fieldsets
     var fieldsetSchema = options.fieldsets || _.result(this, 'fieldsets') || _.result(this.model, 'fieldsets') || [selectedFields],
         fieldsets = this.fieldsets = [];
 
-    _.each(fieldsetSchema, function(itemSchema) {
+    _.each(fieldsetSchema, _.bind(function(itemSchema) {
       this.fieldsets.push(this.createFieldset(itemSchema));
-    }, this);
+    }, this));
   },
 
   /**

--- a/test/editors/extra/list.js
+++ b/test/editors/extra/list.js
@@ -229,7 +229,7 @@ var same = deepEqual;
 
         same(list.items.length, 3);
 
-        same(values, _.pluck(list.items, 'value'));
+        same(values, _.map(list.items, 'value'));
     }
 
     test('render() - creates items for each item in value array', function() {

--- a/test/editors/select.js
+++ b/test/editors/select.js
@@ -95,17 +95,17 @@
     var options = _.map($('option', group), function(el) {
         return $(el).text();
     });
-    ok(_.contains(options, 'Paris'));
-    ok(_.contains(options, 'Beijing'));
-    ok(_.contains(options, 'San Francisco'));
+    ok(~options.indexOf('Paris'));
+    ok(~options.indexOf('Beijing'));
+    ok(~options.indexOf('San Francisco'));
 
     var group = editor.$('optgroup').last();
     equal($('option', group).length, 2);
     var options = _.map($('option', group), function(el) {
         return $(el).text();
     });
-    ok(_.contains(options, 'France'));
-    ok(_.contains(options, 'China'));
+    ok(~options.indexOf('France'));
+    ok(~options.indexOf('China'));
   });
 
   test('Option groups allow to specify option value / label', function() {

--- a/test/lodash.html
+++ b/test/lodash.html
@@ -1,0 +1,170 @@
+<!--
+  TESTS FOR DEVELOPMENT
+  These use the individual source files. Use this while developing
+-->
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+  <link rel="stylesheet" href="lib/qunit.css" type="text/css" media="screen" />
+
+  <!-- TEST LIB FILES -->
+  <script type="text/javascript" src="lib/qunit.js"></script>
+  <script type="text/javascript" src="lib/sinon.js"></script>
+
+  <!-- SRC LIB FILES -->
+  <script src="lib/jquery.js"></script>
+
+  <script src="../bower_components/lodash/lodash.js"></script>
+  <script src="../bower_components/backbone/backbone.js"></script>
+  <script src="../bower_components/backbone-deep-model/dist/deep-model.js"></script>
+
+  <!-- SOURCE FILES -->
+  <script src="../src/form.js"></script>
+  <script src="../src/validators.js"></script>
+  <script src="../src/fieldset.js"></script>
+  <script src="../src/field.js"></script>
+  <script src="../src/nestedField.js"></script>
+  <script src="../src/editor.js"></script>
+
+  <script src="../src/editors/text.js"></script>
+  <script src="../src/editors/textarea.js"></script>
+  <script src="../src/editors/password.js"></script>
+  <script src="../src/editors/number.js"></script>
+  <script src="../src/editors/hidden.js"></script>
+  <script src="../src/editors/checkbox.js"></script>
+  <script src="../src/editors/select.js"></script>
+  <script src="../src/editors/radio.js"></script>
+  <script src="../src/editors/checkboxes.js"></script>
+  <script src="../src/editors/object.js"></script>
+  <script src="../src/editors/nestedmodel.js"></script>
+  <script src="../src/editors/date.js"></script>
+  <script src="../src/editors/datetime.js"></script>
+
+  <script>Backbone.Form = Form</script>
+
+  <script src="../src/editors/extra/list.js"></script>
+</head>
+<body>
+  <div id="qunit"></div>
+  <div id="qunit-fixture">
+    <div id='testElement'>
+      <h1>Test</h1>
+    </div>
+  </div>
+
+  <!-- Main -->
+  <script src="form.js"></script>
+  <script src="fieldset.js"></script>
+  <script src="validators.js"></script>
+  <script src="field.js"></script>
+  <script src="nestedField.js"></script>
+  <script src="editor.js"></script>
+
+  <!-- Editors -->
+  <script src="editors/text.js"></script>
+  <script src="editors/textarea.js"></script>
+  <script src="editors/password.js"></script>
+  <script src="editors/number.js"></script>
+  <script src="editors/hidden.js"></script>
+  <script src="editors/checkbox.js"></script>
+  <script src="editors/select.js"></script>
+  <script src="editors/radio.js"></script>
+  <script src="editors/checkboxes.js"></script>
+  <script src="editors/object.js"></script>
+  <script src="editors/nestedmodel.js"></script>
+  <script src="editors/date.js"></script>
+  <script src="editors/datetime.js"></script>
+
+  <script src="editors/extra/list.js"></script>
+
+
+  <div id="uiTest" style="height: 400px; overflow: auto; border: 1px solid #ccc">
+    <div id="formContainer"></div>
+    <button class="validate">Validate</button>
+  </div>
+  <script>
+    $(function() {
+      var NestedModel = Backbone.Model.extend({
+        schema: {
+          name: { validators: ['required']},
+          email: { validators: ['required', 'email'] }
+        }
+      });
+
+      var schema = {
+        email:      { dataType: 'email', validators: ['required', 'email'] },
+        tel:        { type: 'Text', dataType: 'tel', validators: ['required'], help: 'Include area code' },
+        number:     { type: 'Number', validators: [/[0-9]+(?:\.[0-9]*)?/] },
+        hidden:     { type: 'Hidden' },
+        checkbox:   { type: 'Checkbox' },
+        radio:      { type: 'Radio', options: ['Opt 1', 'Opt 2'] },
+        select:     { type: 'Select', options: ['Opt 1', 'Opt 2'] },
+        groupSelect: { type: 'Select', options: [
+          {
+            group: 'North America', options: [
+              { val: 'ca', label: 'Canada' },
+              { val: 'us', label: 'United States' }
+            ],
+          },
+          {
+            group: 'Europe', options: [
+              { val: 'es', label: 'Spain' },
+              { val: 'fr', label: 'France' },
+              { val: 'uk', label: 'United Kingdom' }
+            ]
+          }
+        ] },
+        checkboxes: { type: 'Checkboxes', options: ['Sterling', 'Lana', 'Cyril', 'Cheryl', 'Pam'] },
+        object:     { type: 'Object', subSchema: {
+          name: {},
+          age:  { type: 'Number' }
+        }},
+        nestedModel: { type: 'NestedModel', model: NestedModel },
+        shorthand: 'Password',
+        date: { type: 'Date' },
+        dateTime: { type: 'DateTime', yearStart: 2000, yearEnd: 1980 },
+
+        //List
+        textList: { type: 'List', itemType: 'Text', validators: ['required', 'email'] },
+        nestedModelList: { type: 'List', itemType: 'NestedModel', model: NestedModel },
+        objList: { type: 'List', itemType: 'Object', subSchema: {
+          name: { type: 'Text', validators: ['required'] },
+          age: 'Number'
+        } }
+      };
+
+      var model = new Backbone.Model({
+        number: null,
+        hidden: 'secret!',
+        checkbox: true,
+        textList: ['item1', 'item2', 'item3']
+      });
+
+      var form = new Backbone.Form({
+        model: model,
+        schema: schema,
+        fieldsets: [
+          ['email', 'tel', 'number', 'hidden', 'checkbox', 'radio', 'select', 'groupSelect', 'checkboxes', 'customTemplate', 'shorthand', 'date', 'dateTime'],
+          { legend: 'Lists', fields: ['textList', 'objList', 'nestedModelList'] },
+          { legend: 'Nested editors', fields: ['object', 'nestedModel'] }
+        ]
+      });
+
+      window.form = form;
+
+      $('#uiTest #formContainer').html(form.render().el);
+
+      $('#uiTest label').click(function() {
+        var name = $(this).attr('for'),
+            $editor = $('#' + name),
+            key = $editor.attr('name');
+
+        console.log(form.getValue(key))
+      });
+
+      $('#uiTest button.validate').click(function() { form.validate() });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Change _.each(..., this) to use _.each(_.bind(..., this))
Remove _.contains and _.pluck from tests
Add tests/lodash.html file to use lodash instead of underscore
Add external libs as bower devDependencies - used in lodash.html
TODO: migrate tests to use bower deps rather than libs and
remove the external libs from the repo where possible.
