### PR TITLE
Allow skipping of schema validation from commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -719,6 +719,8 @@ built-in Backbone model validation. Backbone Forms will run both when
 `form.validate()` is called. Calling `form.commit()` will run schema
 level validation by default, and can also run model validation if `{ validate: true }` is passed.
 
+Calling `form.commit({ schemaValidate: false })` will skip schema level 
+validation and allow you to write dirty form data to the model. Use with care.
 
 ###Schema validation
 

--- a/src/form.js
+++ b/src/form.js
@@ -261,12 +261,14 @@ var Form = Backbone.View.extend({
     options = options || {};
 
     //Collect errors from schema validation
-    _.each(fields, function(field) {
-      var error = field.validate();
-      if (error) {
-        errors[field.key] = error;
-      }
-    });
+    if(!options.skipSchemaValidate) {
+      _.each(fields, function(field) {
+        var error = field.validate();
+        if (error) {
+          errors[field.key] = error;
+        }
+      });
+    }
 
     //Get errors from default Backbone model validator
     if (!options.skipModelValidate && model && model.validate) {
@@ -317,7 +319,8 @@ var Form = Backbone.View.extend({
     options = options || {};
 
     var validateOptions = {
-        skipModelValidate: !options.validate
+        skipModelValidate: !options.validate,
+        skipSchemaValidate: options.schemaValidate === false
     };
 
     var errors = this.validate(validateOptions);

--- a/test/form.js
+++ b/test/form.js
@@ -826,6 +826,25 @@ test('returns validation errors', function() {
   same(err.foo, 'bar');
 });
 
+test('does not return schema validation errors if commit({ schemaValidate: false })', function() {
+  var model = new Backbone.Model;
+
+  model.validate = function() {
+    return 'FOO';
+  };
+
+  var form = new Form({
+    model: model,
+    schema: {
+      title: {validators: ['required']}
+    }
+  });
+
+  var err = form.commit({schemaValidate: false});
+
+  same(err, undefined);
+});
+
 test('does not return  model validation errors by default', function() {
   var model = new Backbone.Model();
 


### PR DESCRIPTION
Like so: `form.commit({ schemaValidate:false })`

This allows data to be written to the model using the handy `form.commit()` method in a preliminary state, before validation. 

Further discussion and usecase in https://github.com/powmedia/backbone-forms/issues/540